### PR TITLE
Prepend iptables rule instead of appending it

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -6,6 +6,21 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 )
 
+func iptablesInsertUnique(ipt *iptables.IPTables, table, chain string, pos int, rulespec ...string) error {
+	exists, err := ipt.Exists(table, chain, rulespec...)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		if err := ipt.Delete(table, chain, rulespec...); err != nil {
+			return err
+		}
+	}
+
+	return ipt.Insert(table, chain, pos, rulespec...)
+}
+
 // AddRule adds the required rule to the host's nat table
 func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 	if hostIP == "" {
@@ -17,8 +32,8 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 		return err
 	}
 
-	if err := ipt.AppendUnique(
-		"nat", "PREROUTING", "-p", "tcp", "-d", metadataAddress, "--dport", "80",
+	if err := iptablesInsertUnique(ipt,
+		"nat", "PREROUTING", 1, "-p", "tcp", "-d", metadataAddress, "--dport", "80",
 		"-j", "DNAT", "--to-destination", hostIP+":"+appPort, "-i", hostInterface,
 	); err != nil {
 		return err


### PR DESCRIPTION
This fixes an issue in Kubernetes when the appended rule is never activated
because it is swalled by pre-existing rules.

Without this PR here is what the PREROUTING table look like:

```
core@ip-10-170-23-119 ~ $ sudo iptables -t nat -L PREROUTING --line-numbers -n
Chain PREROUTING (policy ACCEPT)
num  target     prot opt source               destination
1    KUBE-SERVICES  all  --  0.0.0.0/0            0.0.0.0/0            /* kubernetes service portals */
2    DOCKER     all  --  0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
3    DNAT       tcp  --  0.0.0.0/0            169.254.169.254      tcp dpt:80 to:10.170.23.119:8181

core@ip-10-170-23-119 ~ $ sudo iptables -t nat -L KUBE-SERVICES --line-numbers -n
Chain KUBE-SERVICES (2 references)
num  target     prot opt source               destination
1    KUBE-SVC-DKLLMOGNZZKRVIWM  tcp  --  0.0.0.0/0            192.168.64.58        /* jenkins/jenkins-discovery:slaves cluster IP */ tcp dpt:50000
2    KUBE-SVC-TPZT2TPWTBFEHRUX  tcp  --  0.0.0.0/0            192.168.64.58        /* jenkins/jenkins-discovery:master cluster IP */ tcp dpt:80
3    KUBE-SVC-NPX46M4PTMTKRN6Y  tcp  --  0.0.0.0/0            192.168.64.1         /* default/kubernetes:https cluster IP */ tcp dpt:443
4    KUBE-SVC-XGLOHA7QRQ3V22RZ  tcp  --  0.0.0.0/0            192.168.64.188       /* kube-system/kubernetes-dashboard: cluster IP */ tcp dpt:80
5    KUBE-SVC-HFYXROO3G4KITGSW  tcp  --  0.0.0.0/0            192.168.64.224       /* jenkins/jenkins-ui:ui cluster IP */ tcp dpt:443
6    KUBE-SVC-C6PFMPKKF2D63UAO  tcp  --  0.0.0.0/0            192.168.64.2         /* default/frontend:frontend cluster IP */ tcp dpt:80
7    KUBE-SVC-TCOU7JCQXEZGVUNU  udp  --  0.0.0.0/0            192.168.64.10        /* kube-system/kube-dns:dns cluster IP */ udp dpt:53
8    KUBE-SVC-ERIFXISQEP7F7OF4  tcp  --  0.0.0.0/0            192.168.64.10        /* kube-system/kube-dns:dns-tcp cluster IP */ tcp dpt:53
9    KUBE-SVC-BJM46V3U5RZHCFRZ  tcp  --  0.0.0.0/0            192.168.64.165       /* kube-system/heapster: cluster IP */ tcp dpt:80
10   KUBE-NODEPORTS  all  --  0.0.0.0/0            0.0.0.0/0            /* kubernetes service nodeports; NOTE: this must be the last rule in this chain */ ADDRTYPE match dst-type LOCAL

core@ip-10-170-23-119 ~ $ sudo iptables -t nat -L DOCKER --line-numbers -n
Chain DOCKER (2 references)
num  target     prot opt source               destination
1    RETURN     all  --  0.0.0.0/0            0.0.0.0/0
2    RETURN     all  --  0.0.0.0/0            0.0.0.0/0```

