### PR TITLE
Feature/fail on invalid host interface

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -2,12 +2,19 @@ package iptables
 
 import (
 	"errors"
+	"net"
 
 	"github.com/coreos/go-iptables/iptables"
 )
 
 // AddRule adds the required rule to the host's nat table
 func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
+
+	err := InterfaceExists(hostInterface)
+	if err != nil {
+		return err
+	}
+
 	if hostIP == "" {
 		return errors.New("--host-ip must be set")
 	}
@@ -25,4 +32,9 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 	}
 
 	return nil
+}
+
+func InterfaceExists(hostInterface string) error {
+	_, err := net.InterfaceByName(hostInterface)
+	return err
 }

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -10,8 +10,7 @@ import (
 // AddRule adds the required rule to the host's nat table
 func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 
-	err := InterfaceExists(hostInterface)
-	if err != nil {
+	if err := CheckInterfaceExists(hostInterface); err != nil {
 		return err
 	}
 
@@ -34,7 +33,8 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 	return nil
 }
 
-func InterfaceExists(hostInterface string) error {
+// CheckInterfaceExists - validates the interface passed exists for the given system
+func CheckInterfaceExists(hostInterface string) error {
 	_, err := net.InterfaceByName(hostInterface)
 	return err
 }

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -1,0 +1,37 @@
+package iptables
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func TestInterfaceExistsFailWithBogusInterface(t *testing.T) {
+	ifc := "bogus0"
+	err := InterfaceExists(ifc)
+	if err == nil {
+		t.Error(fmt.Sprintf("Should fail with interface '%s'", ifc))
+	}
+}
+
+func TestInterfaceExistsPassWithValidInterface(t *testing.T) {
+	var ifc string
+	switch os := runtime.GOOS; os {
+	case "darwin":
+		ifc = "lo0"
+	case "linux":
+		ifc = "lo"
+	default:
+		// everything else that we don't know or care about...fail
+		ifc = "unknown"
+		t.Error("%s OS '%s'\n", ifc, os)
+	}
+	err := InterfaceExists(ifc)
+	if err != nil {
+		t.Error(fmt.Sprintf("Should pass with interface '%s'", ifc))
+	}
+}
+
+func TestAddRule(t *testing.T) {
+	t.Skip()
+}

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 )
 
-func TestInterfaceExistsFailWithBogusInterface(t *testing.T) {
+func TestCheckInterfaceExistsFailsWithBogusInterface(t *testing.T) {
 	ifc := "bogus0"
 	if err := CheckInterfaceExists(ifc); err == nil {
-		t.Error("Should fail with interface '%s'", ifc)
+		t.Error("Should fail with invalid interface. Interface received:", ifc)
 	}
 }
 
-func TestInterfaceExistsPassWithValidInterface(t *testing.T) {
+func TestCheckInterfaceExistsPassesWithValidInterface(t *testing.T) {
 	var ifc string
 	switch os := runtime.GOOS; os {
 	case "darwin":
@@ -25,7 +25,7 @@ func TestInterfaceExistsPassWithValidInterface(t *testing.T) {
 		t.Error("%s OS '%s'\n", ifc, os)
 	}
 	if err := CheckInterfaceExists(ifc); err != nil {
-		t.Error("Should pass with interface '%s'", ifc)
+		t.Error("Should pass with valid interface. Interface received:", ifc)
 	}
 }
 

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -1,16 +1,14 @@
 package iptables
 
 import (
-	"fmt"
 	"runtime"
 	"testing"
 )
 
 func TestInterfaceExistsFailWithBogusInterface(t *testing.T) {
 	ifc := "bogus0"
-	err := InterfaceExists(ifc)
-	if err == nil {
-		t.Error(fmt.Sprintf("Should fail with interface '%s'", ifc))
+	if err := CheckInterfaceExists(ifc); err == nil {
+		t.Error("Should fail with interface '%s'", ifc)
 	}
 }
 
@@ -26,9 +24,8 @@ func TestInterfaceExistsPassWithValidInterface(t *testing.T) {
 		ifc = "unknown"
 		t.Error("%s OS '%s'\n", ifc, os)
 	}
-	err := InterfaceExists(ifc)
-	if err != nil {
-		t.Error(fmt.Sprintf("Should pass with interface '%s'", ifc))
+	if err := CheckInterfaceExists(ifc); err != nil {
+		t.Error("Should pass with interface '%s'", ifc)
 	}
 }
 


### PR DESCRIPTION
# Check that host-interface is valid

## What is the problem/feature?

I recently encountered the issue where I ported from https://github.com/kubernetes/kops (on Debian) to https://github.com/kz8s/tack (on CoreOS). 

As part of that migration I forgot to update the `--host-interface=cbr0` to `--host-interface=docker0`

Part of the reason I didn't notice that I had to switch the `--host-interface` was because I deployed the manifest to the cluster and it reported no issues.

While investigating I looked at the `iptables` configuration and noticed it happily created the rule with a non-existent interface name.

This appears to be the way the github.com/coreos/go-iptables/iptables library works.

As per https://github.com/jtblin/kube2iam/blob/0db630422a691d957677746e85b651eb4179360c/iptables/iptables.go#L20

It did not report an error and in fact actually create the rule:

```bash
core@ip-10-10-10-7 ~ $ sudo iptables -S -t nat | grep cbr0
-A PREROUTING -d 169.254.169.254/32 -i cbr0 -p tcp -m tcp --dport 80 -j DNAT --to-destination 10.10.10.7:8181
core@ip-10-10-10-7 ~ $
```

## How did it get fixed/implemented?

- Added a function called `InterfaceExists` to `iptables/iptables.go` which invokes`net.InterfaceByName(hostInterface)`
- Added a call from `AddRule()` to `InterfaceExists()` to check for error
- Added tests around `InterfaceExists()` to test that specific function in isolation
- No common naming between Darwin & Linux network interfaces so it checks for OS via `runtime.GOOS`
- Added test stub for `AddRule()`

## How can someone test/see it?

### Testing Changes
- `git clone git@github.com:johnt337/kube2iam $GOPATH/src/github.com/johnt337/kube2iam`

- `ln -s $GOPATH/src/github.com/johnt337/kube2iam $GOPATH/src/github.com/jtblin/kube2iam`

- `cd $GOPATH/src/github.com/johnt337/kube2iam`

- switch to the branch or commit
    - `git checkout -b feature/fail-on-invalid-host-interface origin/feature/fail-on-invalid-host-interface`
    - (or)`git reset --hard c5b0377c12d73bc2e5e15b17b3064a5086f313dc`

- `make setup && make test`

### Expected Results
![image](https://cloud.githubusercontent.com/assets/1334469/20724302/b5b195ec-b63b-11e6-9c68-bb342bc85004.png)


### Building Changes
- `make docker`
- Testing container image
    - Bogus Interface `docker run --rm -it jtblin/kube2iam:c5b0377 --base-role-arn=arn:aws:iam::123456789012:role/ --iptables=true --host-interface=bogus0 --host-ip=127.0.0.1 --verbose`
    - Valid Interface `docker run --rm -it jtblin/kube2iam:c5b0377 --base-role-arn=arn:aws:iam::123456789012:role/ --iptables=true --host-interface=eth0 --host-ip=127.0.0.1 --verbose`


### Expected Results (on OSX)
![image](https://cloud.githubusercontent.com/assets/1334469/20724207/4e65d7c2-b63b-11e6-8103-80b4ee0b5b3b.png)


## Other comments
- Tests should be run in container for proper isolation & consistency
- Makefile hardcode refs to `github.com/jtblin` should leverage make vars instead to ease contribution