### PR TITLE
Ignore wildcard interface names in interface check

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -3,6 +3,7 @@ package iptables
 import (
 	"errors"
 	"net"
+	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
 )
@@ -33,8 +34,14 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 	return nil
 }
 
-// CheckInterfaceExists - validates the interface passed exists for the given system
+// CheckInterfaceExists - validates the interface passed exists for the given system, ignores calico networks
 func CheckInterfaceExists(hostInterface string) error {
+
+	if strings.Contains(hostInterface, "+") {
+		// calico networks ignored
+		return nil
+	}
+
 	_, err := net.InterfaceByName(hostInterface)
 	return err
 }

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -34,11 +34,11 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 	return nil
 }
 
-// CheckInterfaceExists - validates the interface passed exists for the given system, ignores calico networks
+// CheckInterfaceExists - validates the interface passed exists for the given system, ignores wildcard networks
 func CheckInterfaceExists(hostInterface string) error {
 
 	if strings.Contains(hostInterface, "+") {
-		// calico networks ignored
+		// wildcard networks ignored
 		return nil
 	}
 

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -29,6 +29,13 @@ func TestCheckInterfaceExistsPassesWithValidInterface(t *testing.T) {
 	}
 }
 
+func TestCheckInterfaceExistsPassesWithPlus(t *testing.T) {
+	ifc := "cali+"
+	if err := CheckInterfaceExists(ifc); err != nil {
+		t.Error("Should pass with external networking. Interface received:", ifc)
+	}
+}
+
 func TestAddRule(t *testing.T) {
 	t.Skip()
 }


### PR DESCRIPTION
# Patch to ignore interface names like cali+

## What is the problem/feature?

As per #37 calico networks are passed to kube2iam with the 'cali+' notation.
https://github.com/jtblin/kube2iam/pull/34 did not take this into consideration.

## How did it get fixed/implemented?

- Added conditional to `CheckInterfaceExists` that returns `nil` if a _+_ is detected
- Added a test to support this condition
