### PR TITLE
Namespace restriction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,13 @@ REPO_VERSION := $$(git describe --abbrev=0 --tags)
 BUILD_DATE := $$(date +%Y-%m-%d-%H:%M)
 GIT_HASH := $$(git rev-parse --short HEAD)
 GOBUILD_VERSION_ARGS := -ldflags "-s -X $(VERSION_VAR)=$(REPO_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE)"
-IMAGE_NAME := jtblin/$(BINARY_NAME)
+# useful for other docker repos
+DOCKER_REPO := jtblin
+IMAGE_NAME := $(DOCKER_REPO)/$(BINARY_NAME)
 ARCH ?= darwin
 METALINTER_CONCURRENCY ?= 4
+# useful for passing --build-arg http_proxy :)
+DOCKER_BUILD_FLAGS := 
 
 setup:
 	go get -v -u github.com/Masterminds/glide
@@ -74,7 +78,7 @@ cross:
 	CGO_ENABLED=0 GOOS=linux go build -o build/bin/linux/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) -a -installsuffix cgo  github.com/jtblin/$(BINARY_NAME)
 
 docker: cross
-	docker build -t $(IMAGE_NAME):$(GIT_HASH) .
+	docker build -t $(IMAGE_NAME):$(GIT_HASH) . $(DOCKER_BUILD_FLAGS)
 
 release: check test docker
 	docker push $(IMAGE_NAME):$(GIT_HASH)

--- a/README.md
+++ b/README.md
@@ -190,6 +190,23 @@ spec:
 
 You can use `--default-role` to set a fallback role to use when annotation is not set.
 
+### Namespace Restrictions
+
+By using the flag --namespace-restrictions you can enable a mode in which the roles that pods can assume is restricted by an annotation on the pod's namespace. This annotation should be in the form of a json array.
+
+To allow the aws-cli pod specified above to run in the default namespace your namespace would look like the following.
+
+```
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    kube2iam/allowed-roles: |
+      ["role-name"]
+  name: default
+```
+
 ### Options
 
 By default, `kube2iam` will use the in-cluster method to connect to the kubernetes master, and use the `iam.amazonaws.com/role`
@@ -210,6 +227,8 @@ Usage of kube2iam:
       --insecure                Kubernetes server should be accessed without verifying the TLS. Testing only
       --iptables                Add iptables rule (also requires --host-ip)
       --metadata-addr string    Address for the ec2 metadata (default "169.254.169.254")
+      --namespace-key string    Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array) (default "kube2iam/allowed-roles")
+      --namespace-restrictions  Enable namespace restrictions
       --verbose                 Verbose
       --version                 Print the version and exits
 

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"encoding/json"
+
+	log "github.com/Sirupsen/logrus"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+type namespacehandler struct {
+	storage *store
+}
+
+// OnAdd called with a namespace is added to k8s
+func (h *namespacehandler) OnAdd(obj interface{}) {
+	ns, ok := obj.(*api.Namespace)
+	if !ok {
+		log.Errorf("Expected Namespace but OnAdd handler received %+v", obj)
+		return
+	}
+
+	log.Debugf("Namespace OnAdd %s", ns.GetName())
+
+	roles := h.getRoleAnnotation(ns)
+	if roles != nil {
+		for i := range roles {
+			log.Debugf("- Role %s", roles[i])
+			h.storage.AddRoleToNamespace(ns.GetName(), roles[i])
+		}
+	}
+}
+
+// OnUpdate called with a namespace is updated inside k8s
+func (h *namespacehandler) OnUpdate(oldObj, newObj interface{}) {
+	//ons, ok := oldObj.(*api.Namespace)
+	nns, ok := newObj.(*api.Namespace)
+	if !ok {
+		log.Errorf("Expected Namespace but OnUpdate handler received %+v", newObj)
+		return
+	}
+	log.Debugf("Namespace OnUpdate %s", nns.GetName())
+
+	roles := h.getRoleAnnotation(nns)
+	if roles != nil {
+		nsname := nns.GetName()
+		h.storage.DeleteNamespace(nsname)
+		for i := range roles {
+			log.Debugf("- Role %s", roles[i])
+			h.storage.AddRoleToNamespace(nsname, roles[i])
+		}
+	}
+}
+
+// OnDelete called with a namespace is removed from k8s
+func (h *namespacehandler) OnDelete(obj interface{}) {
+	ns, ok := obj.(*api.Namespace)
+	if !ok {
+		log.Errorf("Expected Namespace but OnDelete handler received %+v", obj)
+		return
+	}
+	log.Debugf("Namespace OnDelete %s", ns.GetName())
+	h.storage.DeleteNamespace(ns.GetName())
+}
+
+// getRoleAnnotations reads the "kube2iam/roles" annotation off a namespace
+// and splits them on comma
+func (h *namespacehandler) getRoleAnnotation(ns *api.Namespace) []string {
+	rolesstring := ns.Annotations[h.storage.namespaceKey]
+	if rolesstring != "" {
+		var decoded []string
+		if err := json.Unmarshal([]byte(rolesstring), &decoded); err != nil {
+			log.Errorf("Unable to decode roles on namespace %s ( role annotation is '%s' )with error: %s", ns.Name, rolesstring, err)
+		}
+		return decoded
+	}
+	return nil
+}
+
+func newNamespacehandler(s *store) *namespacehandler {
+	return &namespacehandler{
+		storage: s,
+	}
+}

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -69,7 +69,7 @@ func (h *namespacehandler) getRoleAnnotation(ns *api.Namespace) []string {
 	if rolesstring != "" {
 		var decoded []string
 		if err := json.Unmarshal([]byte(rolesstring), &decoded); err != nil {
-			log.Errorf("Unable to decode roles on namespace %s ( role annotation is '%s' )with error: %s", ns.Name, rolesstring, err)
+			log.Errorf("Unable to decode roles on namespace %s ( role annotation is '%s' ) with error: %s", ns.Name, rolesstring, err)
 		}
 		return decoded
 	}

--- a/cmd/pod.go
+++ b/cmd/pod.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"k8s.io/kubernetes/pkg/api"
+	kcache "k8s.io/kubernetes/pkg/client/cache"
+)
+
+type podhandler struct {
+	storage *store
+}
+
+// OnAdd is called when a pod is added.
+func (p *podhandler) OnAdd(obj interface{}) {
+	pod, ok := obj.(*api.Pod)
+	if !ok {
+		log.Errorf("Expected Pod but OnAdd handler received %+v", obj)
+		return
+	}
+	log.Debugf("Pod OnAdd %s - %s", pod.GetName(), pod.Status.PodIP)
+
+	p.storage.AddNamespaceToIP(pod)
+
+	if pod.Status.PodIP != "" {
+		if role, ok := pod.Annotations[p.storage.iamRoleKey]; ok {
+			log.Debugf("- Role %s", role)
+			p.storage.AddRoleToIP(pod, role)
+		}
+	}
+}
+
+// OnUpdate is called when a pod is modified.
+func (p *podhandler) OnUpdate(oldObj, newObj interface{}) {
+	oldPod, ok1 := oldObj.(*api.Pod)
+	newPod, ok2 := newObj.(*api.Pod)
+	if !ok1 || !ok2 {
+		log.Errorf("Expected Pod but OnUpdate handler received %+v %+v", oldObj, newObj)
+		return
+	}
+	log.Debugf("Pod OnUpdate %s - %s", newPod.GetName(), newPod.Status.PodIP)
+
+	if oldPod.Status.PodIP != newPod.Status.PodIP {
+		p.OnDelete(oldPod)
+		p.OnAdd(newPod)
+	}
+}
+
+// OnDelete is called when a pod is deleted.
+func (p *podhandler) OnDelete(obj interface{}) {
+	pod, ok := obj.(*api.Pod)
+	if !ok {
+		deletedObj, dok := obj.(kcache.DeletedFinalStateUnknown)
+		if dok {
+			pod, ok = deletedObj.Obj.(*api.Pod)
+		}
+	}
+
+	if !ok {
+		log.Errorf("Expected Pod but OnDelete handler received %+v", obj)
+		return
+	}
+
+	log.Debugf("Pod OnDelete %s - %s", pod.GetName(), pod.Status.PodIP)
+
+	if pod.Status.PodIP != "" {
+		p.storage.DeleteIP(pod.Status.PodIP)
+	}
+}
+
+func newPodhandler(s *store) *podhandler {
+	return &podhandler{
+		storage: s,
+	}
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -43,7 +43,7 @@ type appHandler func(http.ResponseWriter, *http.Request)
 
 // ServeHTTP implements the net/http server Handler interface.
 func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Infof("Requesting %s", r.RequestURI)
+	log.Debugf("Requesting %s", r.RequestURI)
 	log.Debugf("RemoteAddr %s", parseRemoteAddr(r.RemoteAddr))
 	w.Header().Set("Server", "EC2ws")
 	fn(w, r)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -103,7 +103,7 @@ func (s *Server) roleHandler(w http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	if role != vars["role"] {
-		http.Error(w, fmt.Sprintf("Invalid role %s", vars["role"]), http.StatusForbidden)
+		http.Error(w, fmt.Sprintf("Invalid role %s for %s", vars["role"], remoteIP), http.StatusForbidden)
 		return
 	}
 
@@ -115,7 +115,7 @@ func (s *Server) roleHandler(w http.ResponseWriter, r *http.Request) {
 	roleARN := s.iam.roleARN(role)
 	credentials, err := s.iam.assumeRole(roleARN, remoteIP)
 	if err != nil {
-		log.Errorf("Error assuming role %+v", err)
+		log.Errorf("Error assuming role %+v for pod at %s", err, remoteIP)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -133,6 +133,18 @@ func (s *store) CheckNamespaceRestriction(role string, ip string) bool {
 	return s.checkRoleForNamespace(role, ns)
 }
 
+func (s *store) DumpRolesByIP() map[string]string {
+	return s.rolesByIP
+}
+
+func (s *store) DumpRolesByNamespace() map[string][]string {
+	return s.rolesByNamespace
+}
+
+func (s *store) DumpNamespaceByIP() map[string]string {
+	return s.namespaceByIP
+}
+
 func newStore(key string, defaultRole string, namespaceRestriction bool, namespaceKey string) *store {
 	return &store{
 		defaultRole:          defaultRole,

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -104,16 +104,16 @@ func (s *store) DeleteNamespace(namespace string) {
 func (s *store) checkRoleForNamespace(role string, namespace string) bool {
 	ar := s.rolesByNamespace[namespace]
 	if ar == nil {
-		log.Printf("Role:%s on namespace:%s not found.\n", role, namespace)
+		log.Warnf("Role:%s on namespace:%s not found.", role, namespace)
 		return false
 	}
 	for i := range ar {
 		if ar[i] == role {
-			log.Printf("Role:%s on namespace:%s found.\n", role, namespace)
+			log.Debugf("Role:%s on namespace:%s found.", role, namespace)
 			return true
 		}
 	}
-	log.Printf("Role:%s on namespace:%s not found.\n", role, namespace)
+	log.Warnf("Role:%s on namespace:%s not found.", role, namespace)
 	return false
 }
 

--- a/main.go
+++ b/main.go
@@ -54,6 +54,8 @@ func addFlags(s *cmd.Server, fs *pflag.FlagSet) {
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the ec2 metadata")
 	fs.BoolVar(&s.AddIPTablesRule, "iptables", false, "Add iptables rule (also requires --host-ip)")
 	fs.StringVar(&s.HostInterface, "host-interface", "docker0", "Host interface for proxying AWS metadata")
+	fs.BoolVar(&s.NamespaceRestriction, "namespace-restrictions", false, "Enable namespace restrictions")
+	fs.StringVar(&s.NamespaceKey, "namespace-key", s.NamespaceKey, "Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array)")
 	fs.StringVar(&s.HostIP, "host-ip", s.HostIP, "IP address of host")
 	fs.DurationVar(&s.BackoffMaxInterval, "backoff-max-interval", defaultMaxInterval, "Max interval for backoff when querying for role.")
 	fs.DurationVar(&s.BackoffMaxElapsedTime, "backoff-max-elapsed-time", defaultMaxElapsedTime, "Max elapsed time for backoff when querying for role.")

--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ func main() {
 	addFlags(s, pflag.CommandLine)
 	pflag.Parse()
 
+	// default to info or above (probably the default anyways)
+	log.SetLevel(log.InfoLevel)
+
 	if s.Verbose {
 		log.SetLevel(log.DebugLevel)
 	}


### PR DESCRIPTION
This pull request implements a namespace restriction scheme. It's useful in multi-tennent clusters. Roles specified in pod annotations are checked against a list of allowed roles listed in an annotation on the pods namespace.