### PR TITLE
added log statements to make debugging assume-failures easier

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -99,8 +99,11 @@ func (s *Server) roleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	log.Debugf("Got role %s for RemoteAddr %s", role, remoteIP)
+
 	vars := mux.Vars(r)
 	if role != vars["role"] {
+		log.Errorf("Invalid role %s for RemoteAddr %s", role, remoteIP)
 		http.Error(w, fmt.Sprintf("Invalid role %s", vars["role"]), http.StatusForbidden)
 		return
 	}


### PR DESCRIPTION
We were running into some issues with assuming roles and had trouble finding the culprit.

The kube2iam container did not have the _--base-role-arn_ flag and we instead added them in the pod manifests explicitly. However, when requesting the role from the store, kube2iam made a check for the entire ARN against the role given in the route, which obviously failed.

While there might be another issue hidden in here, the additional log messages would have made it very obvious what was going on.