### PR TITLE
Allow full ARN specification for roles, including cross AWS account

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -17,6 +17,7 @@ var cache = ccache.New(ccache.Configure())
 const (
 	ttl               = time.Minute * 15
 	maxSessNameLength = 64
+	fullArnPrefix     = "arn:aws:"
 )
 
 type iam struct {
@@ -35,6 +36,9 @@ type credentials struct {
 }
 
 func (iam *iam) roleARN(role string) string {
+	if strings.HasPrefix(strings.ToLower(role), fullArnPrefix) {
+		return role
+	}
 	return fmt.Sprintf("%s%s", iam.baseARN, role)
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -92,6 +92,7 @@ func (s *Server) securityCredentialsHandler(w http.ResponseWriter, r *http.Reque
 	if s.iam.baseARN == "" && strings.HasPrefix(roleARN, s.iam.baseARN) {
 		idx := strings.LastIndex(roleARN, "/")
 		write(w, roleARN[idx+1:])
+		return
 	}
 	write(w, roleARN)
 }


### PR DESCRIPTION
I built on top of what @negz made (https://github.com/jtblin/kube2iam/pull/51) to fix some bugs and test that roles could be assumed between two AWS accounts assuming the trust roles were set up properly.

My main driver behind this PR was to allow the assumption of a role from another AWS account, which can only be done with a full ARN specifier.

I tested a bunch of combinations including:

- no base ARN + full ARN default role + no annotation
- no base ARN + full ARN default role + full ARN annotation
- base ARN + full ARN default role + no annotation
- base ARN + full ARN default role + full ARN annotation
- base ARN + full ARN default role + simple role name annotation

Seems to be working fine.