### PR TITLE
Fix ARN parsing to not break on aws-us-gov resources

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -17,7 +17,7 @@ var cache = ccache.New(ccache.Configure())
 const (
 	ttl               = time.Minute * 15
 	maxSessNameLength = 64
-	fullArnPrefix     = "arn:aws:"
+	fullArnPrefix     = "arn:"
 )
 
 type iam struct {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -89,7 +89,7 @@ func (s *Server) securityCredentialsHandler(w http.ResponseWriter, r *http.Reque
 	roleARN := s.iam.roleARN(role)
 	// If a base ARN has been supplied and this is not cross-account then
 	// return a simple role-name, otherwise return the full ARN
-	if s.iam.baseARN == "" && strings.HasPrefix(roleARN, s.iam.baseARN) {
+	if s.iam.baseARN != "" && strings.HasPrefix(roleARN, s.iam.baseARN) {
 		idx := strings.LastIndex(roleARN, "/")
 		write(w, roleARN[idx+1:])
 		return


### PR DESCRIPTION
This was an oversight on my part in https://github.com/jtblin/kube2iam/pull/53 - I was not familiar with the us-govt regions of AWS.