### PR TITLE
Adding regexes wildcard capabilities to namespace restriction

### DIFF
--- a/cmd/store.go
+++ b/cmd/store.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"k8s.io/kubernetes/pkg/api"
+	"regexp"
 )
 
 // store implements the k8s framework ResourceEventHandler interface.
@@ -109,6 +110,12 @@ func (s *store) DeleteNamespace(namespace string) {
 func (s *store) checkRoleForNamespace(role string, namespace string) bool {
 	ar := s.rolesByNamespace[namespace]
 	for _, r := range ar {
+		re := regexp.MustCompile(r)
+		if re.MatchString(role) {
+			log.Debugf("Role:%s matching regexp %s on namespace:%s found.", role, r, namespace)
+			return true
+		}
+
 		if r == role {
 			log.Debugf("Role:%s on namespace:%s found.", role, namespace)
 			return true

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -2,24 +2,24 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
-	"k8s.io/kubernetes/pkg/api"
-	"regexp"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // store implements the k8s framework ResourceEventHandler interface.
 type store struct {
-	defaultRole          string
-	iamRoleKey           string
-	namespaceKey         string
-	namespaceRestriction bool
-	mutex                sync.RWMutex
-	rolesByIP            map[string]string
-	rolesByNamespace     map[string][]string
-	namespaceByIP        map[string]string
-	iam                  *iam
+	defaultRole            string
+	iamRoleKey             string
+	namespaceKey           string
+	namespaceRestriction   bool
+	mutex                  sync.RWMutex
+	rolesByIP              map[string]string
+	rolesRegexpByNamespace map[string][]*regexp.Regexp
+	namespaceByIP          map[string]string
+	iam                    *iam
 }
 
 // Get returns the iam role based on IP address.
@@ -36,13 +36,13 @@ func (s *store) Get(IP string) (string, error) {
 	return "", fmt.Errorf("Unable to find role for IP %s", IP)
 }
 
-func (s *store) AddRoleToIP(pod *api.Pod, role string) {
+func (s *store) AddRoleToIP(pod *v1.Pod, role string) {
 	s.mutex.Lock()
 	s.rolesByIP[pod.Status.PodIP] = role
 	s.mutex.Unlock()
 }
 
-func (s *store) AddNamespaceToIP(pod *api.Pod) {
+func (s *store) AddNamespaceToIP(pod *v1.Pod) {
 	namespace := pod.GetNamespace()
 	s.mutex.Lock()
 	s.namespaceByIP[pod.Status.PodIP] = namespace
@@ -57,67 +57,66 @@ func (s *store) DeleteIP(ip string) {
 }
 
 // AddRoleToNamespace takes a role name and adds it to our internal state
-func (s *store) AddRoleToNamespace(namespace string, role string) {
+func (s *store) AddRoleToNamespace(namespace string, regexpForRole string) {
 	// Make sure to add the full ARN of roles to ensure string matching works
-	roleARN := s.iam.roleARN(role)
+	regexpRoleARN := s.iam.roleARN(regexpForRole)
 
-	ar := s.rolesByNamespace[namespace]
+	ar := s.rolesRegexpByNamespace[namespace]
 
-	// this is a tiny bit troubling, we could go with a the rolesByNamespace
+	// this is a tiny bit troubling, we could go with a the rolesRegexpByNamespace
 	// being a map[string]map[string]bool so that deduplication isn't
 	// ever a problem .. but for now...
 	c := true
 	for i := range ar {
-		if ar[i] == roleARN {
+		if ar[i].String() == regexpRoleARN {
 			c = false
 			break
 		}
 	}
 	if c {
-		ar = append(ar, roleARN)
+		re, err := regexp.Compile(regexpRoleARN)
+		if err != nil {
+			log.Debugf("Invalid regexp %s  described on namespace:%s found.", regexpRoleARN, namespace)
+			return
+		}
+		ar = append(ar, re)
 	}
 	s.mutex.Lock()
-	s.rolesByNamespace[namespace] = ar
+	s.rolesRegexpByNamespace[namespace] = ar
 	s.mutex.Unlock()
 }
 
 // RemoveRoleFromNamespace takes a role and removes it from a namespace mapping
-func (s *store) RemoveRoleFromNamespace(namespace string, role string) {
+func (s *store) RemoveRoleFromNamespace(namespace string, regexpForRole string) {
 	// Make sure to remove the full ARN of roles to ensure string matching works
-	roleARN := s.iam.roleARN(role)
+	regexpRoleARN := s.iam.roleARN(regexpForRole)
 
-	ar := s.rolesByNamespace[namespace]
+	ar := s.rolesRegexpByNamespace[namespace]
 	for i := range ar {
-		if ar[i] == roleARN {
+		if ar[i].String() == regexpRoleARN {
 			ar = append(ar[:i], ar[i+1:]...)
 			break
 		}
 	}
 	s.mutex.Lock()
-	s.rolesByNamespace[namespace] = ar
+	s.rolesRegexpByNamespace[namespace] = ar
 	s.mutex.Unlock()
 }
 
 // DeleteNamespace removes all role mappings from a namespace
 func (s *store) DeleteNamespace(namespace string) {
 	s.mutex.Lock()
-	delete(s.rolesByNamespace, namespace)
+	delete(s.rolesRegexpByNamespace, namespace)
 	s.mutex.Unlock()
 }
 
 // checkRoleForNamespace checks the 'database' for a role allowed in a namespace,
 // returns true if the role is found, otheriwse false
 func (s *store) checkRoleForNamespace(role string, namespace string) bool {
-	ar := s.rolesByNamespace[namespace]
+	ar := s.rolesRegexpByNamespace[namespace]
 	for _, r := range ar {
-		re := regexp.MustCompile(r)
-		if re.MatchString(role) {
+		if r.MatchString(role) {
 			log.Debugf("Role:%s matching regexp %s on namespace:%s found.", role, r, namespace)
-			return true
-		}
-
-		if r == role {
-			log.Debugf("Role:%s on namespace:%s found.", role, namespace)
 			return true
 		}
 	}
@@ -146,7 +145,16 @@ func (s *store) DumpRolesByIP() map[string]string {
 }
 
 func (s *store) DumpRolesByNamespace() map[string][]string {
-	return s.rolesByNamespace
+	rolesByNamespace := make(map[string][]string)
+
+	for ns, listOfRegexp := range s.rolesRegexpByNamespace {
+		listOfRoles := make([]string, len(s.rolesRegexpByNamespace[ns]))
+		for _, roleRegexp := range listOfRegexp {
+			listOfRoles = append(listOfRoles, roleRegexp.String())
+		}
+		rolesByNamespace[ns] = listOfRoles
+	}
+	return rolesByNamespace
 }
 
 func (s *store) DumpNamespaceByIP() map[string]string {
@@ -155,13 +163,13 @@ func (s *store) DumpNamespaceByIP() map[string]string {
 
 func newStore(key string, defaultRole string, namespaceRestriction bool, namespaceKey string, iamInstance *iam) *store {
 	return &store{
-		defaultRole:          defaultRole,
-		iamRoleKey:           key,
-		namespaceKey:         namespaceKey,
-		namespaceRestriction: namespaceRestriction,
-		rolesByIP:            make(map[string]string),
-		rolesByNamespace:     make(map[string][]string),
-		namespaceByIP:        make(map[string]string),
-		iam:                  iamInstance,
+		defaultRole:            defaultRole,
+		iamRoleKey:             key,
+		namespaceKey:           namespaceKey,
+		namespaceRestriction:   namespaceRestriction,
+		rolesByIP:              make(map[string]string),
+		rolesRegexpByNamespace: make(map[string][]*regexp.Regexp),
+		namespaceByIP:          make(map[string]string),
+		iam:                    iamInstance,
 	}
 }


### PR DESCRIPTION
If your IAM Roles comes from Cloudformation predicts the specific name could be problematic, these PR enables the cluster admin to allow IAM roles that adheres to some convention, I.E if you have the convention that team name should be part of the cloudformation stack name instead of listing

teamA-powerful-role-LR34563D
you will list
teamA-powerful-role-*
or teamA-*

Of course nothing prevents to specify * which is the behaviour of kube2iam without namespace restrictions.
