### PR TITLE
Run glide install with --strip-vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ setup:
 	go get -v -u github.com/alecthomas/gometalinter
 	go get -v -u github.com/jstemmer/go-junit-report
 	gometalinter --install --update
-	glide install
+	glide install --strip-vendor
 
 build: *.go fmt
 	go build -o build/bin/$(ARCH)/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) github.com/jtblin/$(BINARY_NAME)


### PR DESCRIPTION
Configure glide to not include vendor folder of dependencies.

This prevents vendoring multiple copies of glog and fixes #66 (https://github.com/kubernetes/kubernetes/issues/35096)