### PR TITLE
Flannel needs cni0 not flannel0

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ different than `docker0` depending on which virtual network you use e.g.
 * for kops (on kubenet), use `cbr0`
 * for CNI, use `cni0`
 * for weave use `weave`
+* for flannel use `cni0`
 
 ```
 ---


### PR DESCRIPTION
I'm not even sure this is universally correct, but it was under `kops` and it surprised the hell out of me.  I thought I'd add a note for the next poor soul.