### PR TITLE
Replace role-name with role-arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ metadata:
   labels:
     name: aws-cli
   annotations:
-    iam.amazonaws.com/role: role-name
+    iam.amazonaws.com/role: role-arn
 spec:
   containers:
   - image: fstab/aws-cli
@@ -209,7 +209,7 @@ spec:
   template:
     metadata:
       annotations:
-        iam.amazonaws.com/role: role-name
+        iam.amazonaws.com/role: role-arn
       labels:
         app: nginx
     spec:
@@ -236,7 +236,7 @@ spec:
       template:
         metadata:
           annotations:
-            iam.amazonaws.com/role: role-name
+            iam.amazonaws.com/role: role-arn
         spec:
           restartPolicy: OnFailure
           containers:
@@ -256,7 +256,7 @@ kind: Namespace
 metadata:
   annotations:
     iam.amazonaws.com/allowed-roles: |
-      ["role-name"]
+      ["role-arn"]
   name: default
 ```
 


### PR DESCRIPTION
I was a bit confused why this wasn't working at first, since I used the explicit name of the IAM role, but then realized it's probably the whole ARN.  I'm not sure if this was done for a specific reason but I figured I'd propose changing it to ARN as that's the only way I could get my roles to work.  

Thanks for the awesome project!