### PR TITLE
iptables: style clean ups

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -8,10 +8,10 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 )
 
-// AddRule adds the required rule to the host's nat table
+// AddRule adds the required rule to the host's nat table.
 func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 
-	if err := CheckInterfaceExists(hostInterface); err != nil {
+	if err := checkInterfaceExists(hostInterface); err != nil {
 		return err
 	}
 
@@ -24,18 +24,15 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 		return err
 	}
 
-	if err := ipt.AppendUnique(
+	return ipt.AppendUnique(
 		"nat", "PREROUTING", "-p", "tcp", "-d", metadataAddress, "--dport", "80",
 		"-j", "DNAT", "--to-destination", hostIP+":"+appPort, "-i", hostInterface,
-	); err != nil {
-		return err
-	}
-
-	return nil
+	)
 }
 
-// CheckInterfaceExists - validates the interface passed exists for the given system, ignores wildcard networks
-func CheckInterfaceExists(hostInterface string) error {
+// checkInterfaceExists validates the interface passed exists for the given system.
+// checkInterfaceExists ignores wildcard networks.
+func checkInterfaceExists(hostInterface string) error {
 
 	if strings.Contains(hostInterface, "+") {
 		// wildcard networks ignored

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCheckInterfaceExistsFailsWithBogusInterface(t *testing.T) {
 	ifc := "bogus0"
-	if err := CheckInterfaceExists(ifc); err == nil {
+	if err := checkInterfaceExists(ifc); err == nil {
 		t.Error("Should fail with invalid interface. Interface received:", ifc)
 	}
 }
@@ -22,16 +22,16 @@ func TestCheckInterfaceExistsPassesWithValidInterface(t *testing.T) {
 	default:
 		// everything else that we don't know or care about...fail
 		ifc = "unknown"
-		t.Error("%s OS '%s'\n", ifc, os)
+		t.Fatalf("%s OS '%s'\n", ifc, os)
 	}
-	if err := CheckInterfaceExists(ifc); err != nil {
+	if err := checkInterfaceExists(ifc); err != nil {
 		t.Error("Should pass with valid interface. Interface received:", ifc)
 	}
 }
 
 func TestCheckInterfaceExistsPassesWithPlus(t *testing.T) {
 	ifc := "cali+"
-	if err := CheckInterfaceExists(ifc); err != nil {
+	if err := checkInterfaceExists(ifc); err != nil {
 		t.Error("Should pass with external networking. Interface received:", ifc)
 	}
 }


### PR DESCRIPTION
Some small clean ups I spotted while reading the code.

 - simplify error handling in AddRule
 - unexport CheckInterfaceExists; it's not called outside iptables
 - fix go vet errors in iptables_test.go