### PR TITLE
Allow base-role-arn with added paths to be valid.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.Version, "version", false, "Print the version and exits")
 }
 
-var arnRegexp = regexp.MustCompile(`^arn:\w*:iam:\w*:\w*:role\/?$`)
+var arnRegexp = regexp.MustCompile(`^arn:\w*:iam:\w*:\w*:role\/(\w+\/*)*$`)
 
 func main() {
 	s := server.NewServer()


### PR DESCRIPTION
I use a path as part of the role so that we can limit access of assumption. The validation commit in 0.6.3 does not seem to allow for extra paths as I get a validation error on the base-role-arn. 

This PR extends the reg ex validation to allow arbitrary extra paths on the role.