### PR TITLE
Fix for roles with a custom path name

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -202,8 +202,7 @@ func (s *Server) securityCredentialsHandler(logger *log.Entry, w http.ResponseWr
 	// If a base ARN has been supplied and this is not cross-account then
 	// return a simple role-name, otherwise return the full ARN
 	if s.iam.BaseARN != "" && strings.HasPrefix(roleARN, s.iam.BaseARN) {
-		idx := strings.LastIndex(roleARN, "/")
-		write(logger, w, roleARN[idx+1:])
+		write(logger, w, strings.TrimPrefix(roleARN, s.iam.baseARN))
 		return
 	}
 	write(logger, w, roleARN)


### PR DESCRIPTION
It's possible to scope roles to a custom path (arn:aws:iam::123456789012:role/team-a/test-role). The current implementation doesn't support this. Instead of test-role this fix will return team-a/test-role within the securityCredentialsHandler handler. See http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html for more details
about role paths.