### PR TITLE
Customizable log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ spec:
 You can use `--default-role` to set a fallback role to use when annotation is not set.
 
 #### ReplicaSet, CronJob, Deployment, etc.
- 
+
 When creating higher-level abstractions than pods, you need to pass the annotation in the pod template of the  
 resource spec.
 
@@ -291,7 +291,7 @@ Usage of ./build/bin/darwin/kube2iam:
       --api-token string                    Token to authenticate with the api server
       --app-port string                     Http port (default "8181")
       --auto-discover-base-arn              Queries EC2 Metadata to determine the base ARN
-      --auto-discover-default-role          Queries EC2 Metadata to determine the default Iam Role, cannot be used with --default-role
+      --auto-discover-default-role          Queries EC2 Metadata to determine the default Iam Role and base ARN, cannot be used with --default-role, overwrites any previous setting for --base-role-arn
       --backoff-max-elapsed-time duration   Max elapsed time for backoff when querying for role. (default 2s)
       --backoff-max-interval duration       Max interval for backoff when querying for role. (default 1s)
       --base-role-arn string                Base role ARN
@@ -302,6 +302,7 @@ Usage of ./build/bin/darwin/kube2iam:
       --iam-role-key string                 Pod annotation key used to retrieve the IAM role (default "iam.amazonaws.com/role")
       --insecure                            Kubernetes server should be accessed without verifying the TLS. Testing only
       --iptables                            Add iptables rule (also requires --host-ip)
+      --log-level string                    Log level (default "info")
       --metadata-addr string                Address for the ec2 metadata (default "169.254.169.254")
       --namespace-key string                Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array) (default "iam.amazonaws.com/allowed-roles")
       --namespace-restrictions              Enable namespace restrictions
@@ -314,7 +315,7 @@ Usage of ./build/bin/darwin/kube2iam:
 * Use [minikube](https://github.com/kubernetes/minikube) to run cluster locally
 * Build and push dev image to docker hub: `make docker-dev DOCKER_REPO=<your docker hub username>`
 * Update `deployment.yaml` as needed
-* Deploy to local kubernetes cluster: `kubectl create -f deployment.yaml` or 
+* Deploy to local kubernetes cluster: `kubectl create -f deployment.yaml` or
 `kubectl delete -f deployment.yaml && kubectl create -f deployment.yaml`
 * Expose as service: `kubectl expose deployment kube2iam --type=NodePort`
 * Retrieve the services url: `minikube service kube2iam --url`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"github.com/jtblin/kube2iam/iam"
@@ -32,6 +32,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.StringVar(&s.HostIP, "host-ip", s.HostIP, "IP address of host")
 	fs.DurationVar(&s.BackoffMaxInterval, "backoff-max-interval", s.BackoffMaxInterval, "Max interval for backoff when querying for role.")
 	fs.DurationVar(&s.BackoffMaxElapsedTime, "backoff-max-elapsed-time", s.BackoffMaxElapsedTime, "Max elapsed time for backoff when querying for role.")
+	fs.StringVar(&s.LogLevel, "log-level", s.LogLevel, "Log level")
 	fs.BoolVar(&s.Verbose, "verbose", false, "Verbose")
 	fs.BoolVar(&s.Version, "version", false, "Print the version and exits")
 }
@@ -41,7 +42,7 @@ func main() {
 	addFlags(s, pflag.CommandLine)
 	pflag.Parse()
 
-	log.SetLevel(log.InfoLevel)
+	log.ParseLevel(s.LogLevel)
 	if s.Verbose {
 		log.SetLevel(log.DebugLevel)
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d9e605078c7cdb67a45ebaa687f483e578c5dbb4abffcafae80ec9c3d3073ecc
-updated: 2017-04-25T12:19:37.653570586+10:00
+hash: 5518d7a143faceea0ce3c96fcc51502d95ba702f97b6b48bd1e888e59b3ff7ad
+updated: 2017-07-28T21:34:41.017271022+02:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -64,7 +64,7 @@ imports:
   - digest
   - reference
 - name: github.com/emicklei/go-restful
-  version: 09691a3b6378b740595c1002f40c34dd5f218a22
+  version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
   subpackages:
   - log
   - swagger
@@ -81,18 +81,18 @@ imports:
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
-  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
+  version: e18d7aa8f8c624c915db340349aad4c49b10d173
   subpackages:
   - proto
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
   subpackages:
   - proto
 - name: github.com/google/gofuzz
-  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
@@ -117,16 +117,16 @@ imports:
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
-- name: github.com/Sirupsen/logrus
-  version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
+- name: github.com/sirupsen/logrus
+  version: a3f95b5c423586578a4e099b11a46c2479628cac
 - name: github.com/spf13/pflag
   version: dabebe21bf790f782ea4c7bbd2efc430de182afd
 - name: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
   subpackages:
   - codec
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
   - context
   - context/ctxhttp
@@ -175,7 +175,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/apimachinery
-  version: 836ee7c3beaa3f1b25f682e5c4b3594d6b50f6a2
+  version: 85ace5365f33b16fc735c866a12e3c765b9700f2
   subpackages:
   - pkg/util/runtime
   - pkg/util/wait

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,8 +1,7 @@
 package: github.com/jtblin/kube2iam
 import:
-- package: github.com/Sirupsen/logrus
 - package: github.com/aws/aws-sdk-go
-  version: v1.8.7 
+  version: v1.8.7
   subpackages:
   - aws
   - aws/session
@@ -24,3 +23,5 @@ import:
   version: v0.1.0
   subpackages:
   - iptables
+- package: github.com/sirupsen/logrus
+  version: ^1.0.2

--- a/namespace.go
+++ b/namespace.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/jtblin/kube2iam/store"

--- a/pod.go
+++ b/pod.go
@@ -3,7 +3,7 @@ package kube2iam
 import (
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 

--- a/server/server.go
+++ b/server/server.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/cenk/backoff"
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/jtblin/kube2iam"
 	"github.com/jtblin/kube2iam/iam"
@@ -25,6 +25,7 @@ import (
 const (
 	defaultAppPort         = "8181"
 	defaultIAMRoleKey      = "iam.amazonaws.com/role"
+	defaultLogLevel        = "info"
 	defaultMaxElapsedTime  = 2 * time.Second
 	defaultMaxInterval     = 1 * time.Second
 	defaultMetadataAddress = "169.254.169.254"
@@ -44,6 +45,7 @@ type Server struct {
 	HostInterface           string
 	HostIP                  string
 	NamespaceKey            string
+	LogLevel                string
 	AddIPTablesRule         bool
 	AutoDiscoverBaseArn     bool
 	AutoDiscoverDefaultRole bool
@@ -305,6 +307,7 @@ func NewServer() *Server {
 		BackoffMaxElapsedTime: defaultMaxElapsedTime,
 		IAMRoleKey:            defaultIAMRoleKey,
 		BackoffMaxInterval:    defaultMaxInterval,
+		LogLevel:              defaultLogLevel,
 		MetadataAddress:       defaultMetadataAddress,
 		NamespaceKey:          defaultNamespaceKey,
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/jtblin/kube2iam/iam"


### PR DESCRIPTION
Add a --log-level flag to customize the log-level.

In our day-to-day operations we found the default Info log-level a bit to verbose
and would like to only see errors.