### PR TITLE
Incorrect ip to namespace table for pods in a failed state.

### DIFF
--- a/pod.go
+++ b/pod.go
@@ -18,10 +18,11 @@ type PodHandler struct {
 
 func (p *PodHandler) podFields(pod *v1.Pod) log.Fields {
 	return log.Fields{
-		"pod.name":      pod.GetName(),
-		"pod.namespace": pod.GetNamespace(),
-		"pod.status.ip": pod.Status.PodIP,
-		"pod.iam.role":  pod.GetAnnotations()[p.storage.IamRoleKey],
+		"pod.name":         pod.GetName(),
+		"pod.namespace":    pod.GetNamespace(),
+		"pod.status.ip":    pod.Status.PodIP,
+		"pod.status.phase": pod.Status.Phase,
+		"pod.iam.role":     pod.GetAnnotations()[p.storage.IamRoleKey],
 	}
 }
 
@@ -32,6 +33,12 @@ func (p *PodHandler) OnAdd(obj interface{}) {
 		log.Errorf("Expected Pod but OnAdd handler received %+v", obj)
 		return
 	}
+
+	// Only add our namespace map if the container is "Running"
+	if pod.Status.Phase != "Running" {
+		return
+	}
+
 	logger := log.WithFields(p.podFields(pod))
 	logger.Debug("Pod OnAdd")
 
@@ -58,6 +65,12 @@ func (p *PodHandler) OnUpdate(oldObj, newObj interface{}) {
 		log.Errorf("Expected Pod but OnUpdate handler received %+v %+v", oldObj, newObj)
 		return
 	}
+
+	// Only update our namespace map if the container is "Running"
+	if newPod.Status.Phase != "Running" {
+		return
+	}
+
 	logger := log.WithFields(p.podFields(newPod))
 	logger.Debug("Pod OnUpdate")
 


### PR DESCRIPTION
We run a number of cronjobs in our environment.

These pods finish running in a Complete or Failed state and linger for sometime. Unfortunately kubernetes leaves the PodIP intact that was used for these pods.

If docker reuses these ips then we have a conflict and this leads to ips being flagged against the wrong namespace. This breaks the restricted namespace functionality.

This change restricts the namespace tracking to pods in a Running phase.

This might not be a complete solution to this issue but maybe it can start a dialogue.