### PR TITLE
Change ARN Regexp to allow dots on role names

### DIFF
--- a/iam/arn.go
+++ b/iam/arn.go
@@ -13,7 +13,7 @@ const fullArnPrefix = "arn:"
 
 // ARNRegexp is the regex to check that the base ARN is valid,
 // see http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns.
-var ARNRegexp = regexp.MustCompile(`^arn:(\w|-)*:iam::\d+:role\/?(\w+|-|\/)*$`)
+var ARNRegexp = regexp.MustCompile(`^arn:(\w|-)*:iam::\d+:role\/?(\w+|-|\/|\.)*$`)
 
 // IsValidBaseARN validates that the base ARN is valid.
 func IsValidBaseARN(arn string) bool {

--- a/iam/arn_test.go
+++ b/iam/arn_test.go
@@ -10,6 +10,7 @@ func TestIsValidBaseARN(t *testing.T) {
 		"arn:aws:iam::123456789012:role/path/",
 		"arn:aws:iam::123456789012:role/path/sub-path",
 		"arn:aws:iam::123456789012:role/path/sub_path",
+		"arn:aws:iam::123456789012:role/subdomain.domain",
 		"arn:aws:iam::123456789012:role",
 		"arn:aws:iam::123456789012:role/",
 		"arn:aws:iam::123456789012:role-part",


### PR DESCRIPTION
I've found out that the regexp doesn't allow names with dots on itm but this is allowed by AWS.

I'm deploying kubernetes clusters with kops, and it creates IAM roles with the domains on it, so they have dots.