### PR TITLE
Limit relevant pods to those on the same node as kube2iam

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ spec:
           name: kube2iam
           args:
             - "--base-role-arn=arn:aws:iam::123456789012:role/"
+            - "--node=$(NODE_NAME)"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           ports:
             - containerPort: 8181
               hostPort: 8181
@@ -159,11 +165,16 @@ spec:
             - "--base-role-arn=arn:aws:iam::123456789012:role/"
             - "--iptables=true"
             - "--host-ip=$(HOST_IP)"
+            - "--node=$(NODE_NAME)"
           env:
             - name: HOST_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           ports:
             - containerPort: 8181
               hostPort: 8181

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,6 +30,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.NamespaceRestriction, "namespace-restrictions", false, "Enable namespace restrictions")
 	fs.StringVar(&s.NamespaceKey, "namespace-key", s.NamespaceKey, "Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array)")
 	fs.StringVar(&s.HostIP, "host-ip", s.HostIP, "IP address of host")
+	fs.StringVar(&s.NodeName, "node", s.NodeName, "Name of the node where kube2iam is running")
 	fs.DurationVar(&s.BackoffMaxInterval, "backoff-max-interval", s.BackoffMaxInterval, "Max interval for backoff when querying for role.")
 	fs.DurationVar(&s.BackoffMaxElapsedTime, "backoff-max-elapsed-time", s.BackoffMaxElapsedTime, "Max elapsed time for backoff when querying for role.")
 	fs.StringVar(&s.LogLevel, "log-level", s.LogLevel, "Log level")
@@ -101,7 +102,7 @@ func main() {
 		}
 	}
 
-	if err := s.Run(s.APIServer, s.APIToken, s.Insecure); err != nil {
+	if err := s.Run(s.APIServer, s.APIToken, s.NodeName, s.Insecure); err != nil {
 		log.Fatalf("%s", err)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -46,6 +46,7 @@ type Server struct {
 	MetadataAddress         string
 	HostInterface           string
 	HostIP                  string
+	NodeName                string
 	NamespaceKey            string
 	LogLevel                string
 	AddIPTablesRule         bool
@@ -259,8 +260,8 @@ func write(logger *log.Entry, w http.ResponseWriter, s string) {
 }
 
 // Run runs the specified Server.
-func (s *Server) Run(host, token string, insecure bool) error {
-	k, err := k8s.NewClient(host, token, insecure)
+func (s *Server) Run(host, token, nodeName string, insecure bool) error {
+	k, err := k8s.NewClient(host, token, nodeName, insecure)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In clusters with 1000s of pods the memory used by each kube2iam
instance explodes because each kube2iam instance is storing information
about all pods on all nodes in memory.

This adds a flag `--node` for specifying the node name of kube2iam. If
set, it will limit the pods it's watching to those only on the same
node as the kube2iam instance.