### PR TITLE
Automatic IP tables configuration fails when using a specified metada…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.StringVar(&s.IAMRoleKey, "iam-role-key", s.IAMRoleKey, "Pod annotation key used to retrieve the IAM role")
 	fs.BoolVar(&s.Insecure, "insecure", false, "Kubernetes server should be accessed without verifying the TLS. Testing only")
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the ec2 metadata")
+	fs.StringVar(&s.MetadataPort, "metadata-port", s.MetadataPort, "Port for the ec2 metadata")
 	fs.BoolVar(&s.AddIPTablesRule, "iptables", false, "Add iptables rule (also requires --host-ip)")
 	fs.BoolVar(&s.AutoDiscoverBaseArn, "auto-discover-base-arn", false, "Queries EC2 Metadata to determine the base ARN")
 	fs.BoolVar(&s.AutoDiscoverDefaultRole, "auto-discover-default-role", false, "Queries EC2 Metadata to determine the default Iam Role and base ARN, cannot be used with --default-role, overwrites any previous setting for --base-role-arn")
@@ -96,7 +97,7 @@ func main() {
 	}
 
 	if s.AddIPTablesRule {
-		if err := iptables.AddRule(s.AppPort, s.MetadataAddress, s.HostInterface, s.HostIP); err != nil {
+		if err := iptables.AddRule(s.AppPort, s.MetadataAddress, s.MetadataPort, s.HostInterface, s.HostIP); err != nil {
 			log.Fatalf("%s", err)
 		}
 	}

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -18,7 +18,8 @@ spec:
           args:
             - "--app-port=8181"
             - "--base-role-arn=arn:aws:iam::936664463856:role/"
-            - "--metadata-addr=127.0.0.1:9090"
+            - "--metadata-addr=127.0.0.1"
+            - "--metadata-port=9090"
             - "--verbose"
           imagePullPolicy: Always
           ports:

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -9,7 +9,7 @@ import (
 )
 
 // AddRule adds the required rule to the host's nat table.
-func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
+func AddRule(appPort, metadataAddress, metadataPort, hostInterface, hostIP string) error {
 
 	if err := checkInterfaceExists(hostInterface); err != nil {
 		return err
@@ -25,7 +25,7 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 	}
 
 	return ipt.AppendUnique(
-		"nat", "PREROUTING", "-p", "tcp", "-d", metadataAddress, "--dport", "80",
+		"nat", "PREROUTING", "-p", "tcp", "-d", metadataAddress, "--dport", metadataPort,
 		"-j", "DNAT", "--to-destination", hostIP+":"+appPort, "-i", hostInterface,
 	)
 }


### PR DESCRIPTION
…ta address

Originally, the metadata address included both the host and port of the metadata
service.

The iptables rule adder had a hard coded port of 80 and would fail if the metadata
address included a port.

Added an extra paraemeter of --metadata-port to solve this.

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>