### PR TITLE
server: match 'iam/security-credentials' regardless of trailing slash

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -281,13 +281,13 @@ func (s *Server) Run(host, token string, insecure bool) error {
 		log.Debugln("Caches have been synced.  Proceeding with server.")
 	}
 
-	r := mux.NewRouter()
+	r := mux.NewRouter().StrictSlash(true)
 
 	if s.Debug {
 		// This is a potential security risk if enabled in some clusters, hence the flag
 		r.Handle("/debug/store", appHandler(s.debugStoreHandler))
 	}
-	r.Handle("/{version}/meta-data/iam/security-credentials/", appHandler(s.securityCredentialsHandler))
+	r.Handle("/{version}/meta-data/iam/security-credentials", appHandler(s.securityCredentialsHandler))
 	r.Handle("/{version}/meta-data/iam/security-credentials/{role:.*}", appHandler(s.roleHandler))
 	r.Handle("/healthz", appHandler(s.healthHandler))
 	r.Handle("/{path:.*}", appHandler(s.reverseProxyHandler))


### PR DESCRIPTION
aws-sdk-go and boto have different behaviors when calling
'iam/security-credentials'. The former calls
'iam/security-credentials', while the latter calls
'iam/security-credentials/'. This could also be the case
with other clients.

When aws-sdk-go calls the metadata API without the
trailing slash, kube2iam doesn't catch it and thus
returns the node's role rather than the expected
role for the pod. The client then tries to assume
that role and fails thanks for the roleHandler's
circuit breaker "Invalid role: does not match
annotated role".

#### Before, with curl:
```
$ curl "http://169.254.169.254/latest/meta-data/iam/security-credentials"
masters.k8s-quentin # node's role

$ curl "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
tf/k8s/k8s-quentin/prometheus-discovery-etcd.pods.k8s-quentin # pod's role
```

#### Before, with aws-sdk-go:
```
package main

import (
    "fmt"

    "github.com/aws/aws-sdk-go/aws"
    "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
    "github.com/aws/aws-sdk-go/aws/session"
)

func main() {
    sess := session.New(&aws.Config{LogLevel: aws.LogLevel(aws.LogDebugWithHTTPBody)})
    creds := ec2rolecreds.NewCredentials(sess)
    fmt.Println(creds.Get())
}
```

```
$ go run test.go
2018/01/09 03:36:55 DEBUG: Request ec2metadata/GetMetadata Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET /latest/meta-data/iam/security-credentials HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go/1.12.57 (go1.9.2; linux; amd64)
Accept-Encoding: gzip


-----------------------------------------------------
2018/01/09 03:36:55 DEBUG: Response ec2metadata/GetMetadata Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Content-Length: 19
Accept-Ranges: none
Content-Type: text/plain
Date: Tue, 09 Jan 2018 03:36:55 GMT
Last-Modified: Tue, 09 Jan 2018 03:15:19 GMT
Server: EC2ws


-----------------------------------------------------
2018/01/09 03:36:55 masters.k8s-quentin
2018/01/09 03:36:55 DEBUG: Request ec2metadata/GetMetadata Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET /latest/meta-data/iam/security-credentials/masters.k8s-quentin HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go/1.12.57 (go1.9.2; linux; amd64)
Accept-Encoding: gzip


-----------------------------------------------------
2018/01/09 03:36:55 DEBUG: Response ec2metadata/GetMetadata Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 403 Forbidden
Content-Length: 33
Content-Type: text/plain; charset=utf-8
Date: Tue, 09 Jan 2018 03:36:55 GMT
Server: EC2ws
X-Content-Type-Options: nosniff


-----------------------------------------------------
2018/01/09 03:36:55 Invalid role masters.k8s-quentin

{   } EC2RoleRequestError: failed to get masters.k8s-quentin EC2 instance role credentials
caused by: EC2MetadataError: failed to make EC2Metadata request
caused by: Invalid role masters.k8s-quentin
```

#### After, with curl:
```
$ curl "http://169.254.169.254/latest/meta-data/iam/security-credentials"
tf/k8s/k8s-quentin/prometheus-discovery-etcd.pods.k8s-quentin

$ curl -L "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
tf/k8s/k8s-quentin/prometheus-discovery-etcd.pods.k8s-quentin
```

### After, with aws-sdk-go:
```
$ go run test.go
2018/01/09 04:12:13 DEBUG: Request ec2metadata/GetMetadata Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET /latest/meta-data/iam/security-credentials HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go/1.12.57 (go1.9.2; linux; amd64)
Accept-Encoding: gzip


-----------------------------------------------------
2018/01/09 04:12:13 DEBUG: Response ec2metadata/GetMetadata Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Content-Length: 61
Content-Type: text/plain; charset=utf-8
Date: Tue, 09 Jan 2018 04:12:13 GMT
Server: EC2ws


-----------------------------------------------------
2018/01/09 04:12:13 tf/k8s/k8s-quentin/prometheus-discovery-etcd.pods.k8s-quentin
2018/01/09 04:12:13 DEBUG: Request ec2metadata/GetMetadata Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET /latest/meta-data/iam/security-credentials/tf/k8s/k8s-quentin/prometheus-discovery-etcd.pods.k8s-quentin HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go/1.12.57 (go1.9.2; linux; amd64)
Accept-Encoding: gzip


-----------------------------------------------------
2018/01/09 04:12:13 DEBUG: Response ec2metadata/GetMetadata Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Content-Length: 647
Content-Type: text/plain; charset=utf-8
Date: Tue, 09 Jan 2018 04:12:13 GMT
Server: EC2ws


-----------------------------------------------------
2018/01/09 04:12:13 {"AccessKeyId":"XXX","Code":"Success","Expiration":"2018-01-09T04:32:18Z","LastUpdated":"2018-01-09T04:02:18Z","SecretAccessKey":"YYY","Type":"AWS-HMAC"}

{XXX YYY EC2RoleProvider} <nil>
```