### PR TITLE
Add --remove-iptables-on-exit option to delete iptables rule on grace…

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Usage of ./build/bin/darwin/kube2iam:
       --iam-role-key string                 Pod annotation key used to retrieve the IAM role (default "iam.amazonaws.com/role")
       --insecure                            Kubernetes server should be accessed without verifying the TLS. Testing only
       --iptables                            Add iptables rule (also requires --host-ip)
+      --remove-iptables-on-exit             Attempt to remove iptables rule on exit (also requires --iptables)
       --log-level string                    Log level (default "info")
       --metadata-addr string                Address for the ec2 metadata (default "169.254.169.254")
       --namespace-key string                Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array) (default "iam.amazonaws.com/allowed-roles")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.Insecure, "insecure", false, "Kubernetes server should be accessed without verifying the TLS. Testing only")
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the ec2 metadata")
 	fs.BoolVar(&s.AddIPTablesRule, "iptables", false, "Add iptables rule (also requires --host-ip)")
+	fs.BoolVar(&s.RemoveIPTablesRuleOnExit, "remove-iptables-on-exit", false, "Attempt to remove iptables rule on exit (also requires --iptables)")
 	fs.BoolVar(&s.AutoDiscoverBaseArn, "auto-discover-base-arn", false, "Queries EC2 Metadata to determine the base ARN")
 	fs.BoolVar(&s.AutoDiscoverDefaultRole, "auto-discover-default-role", false, "Queries EC2 Metadata to determine the default Iam Role and base ARN, cannot be used with --default-role, overwrites any previous setting for --base-role-arn")
 	fs.StringVar(&s.HostInterface, "host-interface", "docker0", "Host interface for proxying AWS metadata")
@@ -101,7 +102,19 @@ func main() {
 		}
 	}
 
+	if s.RemoveIPTablesRuleOnExit {
+		if !s.AddIPTablesRule {
+			log.Fatalf("You cannot use --remove-iptables-on-exit without also specifying --iptables")
+		}
+		defer func() {
+			if err := iptables.DeleteRule(s.AppPort, s.MetadataAddress, s.HostInterface, s.HostIP); err != nil {
+				log.Fatalf("%s", err)
+			}
+		}()
+	}
+
 	if err := s.Run(s.APIServer, s.APIToken, s.Insecure); err != nil {
 		log.Fatalf("%s", err)
 	}
+
 }

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -30,6 +30,7 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 	)
 }
 
+// DeleteRule deletes the specified rule from the host's nat table.
 func DeleteRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 
 	ipt, err := iptables.New()

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -30,6 +30,19 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 	)
 }
 
+func DeleteRule(appPort, metadataAddress, hostInterface, hostIP string) error {
+
+	ipt, err := iptables.New()
+	if err != nil {
+		return err
+	}
+
+	return ipt.Delete(
+		"nat", "PREROUTING", "-p", "tcp", "-d", metadataAddress, "--dport", "80",
+		"-j", "DNAT", "--to-destination", hostIP+":"+appPort, "-i", hostInterface,
+	)
+}
+
 // checkInterfaceExists validates the interface passed exists for the given system.
 // checkInterfaceExists ignores wildcard networks.
 func checkInterfaceExists(hostInterface string) error {

--- a/server/server.go
+++ b/server/server.go
@@ -37,30 +37,31 @@ const (
 // Server encapsulates all of the parameters necessary for starting up
 // the server. These can either be set via command line or directly.
 type Server struct {
-	APIServer               string
-	APIToken                string
-	AppPort                 string
-	BaseRoleARN             string
-	DefaultIAMRole          string
-	IAMRoleKey              string
-	MetadataAddress         string
-	HostInterface           string
-	HostIP                  string
-	NamespaceKey            string
-	LogLevel                string
-	AddIPTablesRule         bool
-	AutoDiscoverBaseArn     bool
-	AutoDiscoverDefaultRole bool
-	Debug                   bool
-	Insecure                bool
-	NamespaceRestriction    bool
-	Verbose                 bool
-	Version                 bool
-	iam                     *iam.Client
-	k8s                     *k8s.Client
-	roleMapper              *mappings.RoleMapper
-	BackoffMaxElapsedTime   time.Duration
-	BackoffMaxInterval      time.Duration
+	APIServer                string
+	APIToken                 string
+	AppPort                  string
+	BaseRoleARN              string
+	DefaultIAMRole           string
+	IAMRoleKey               string
+	MetadataAddress          string
+	HostInterface            string
+	HostIP                   string
+	NamespaceKey             string
+	LogLevel                 string
+	AddIPTablesRule          bool
+	RemoveIPTablesRuleOnExit bool
+	AutoDiscoverBaseArn      bool
+	AutoDiscoverDefaultRole  bool
+	Debug                    bool
+	Insecure                 bool
+	NamespaceRestriction     bool
+	Verbose                  bool
+	Version                  bool
+	iam                      *iam.Client
+	k8s                      *k8s.Client
+	roleMapper               *mappings.RoleMapper
+	BackoffMaxElapsedTime    time.Duration
+	BackoffMaxInterval       time.Duration
 }
 
 type appHandler func(*log.Entry, http.ResponseWriter, *http.Request)


### PR DESCRIPTION
Referencing https://github.com/jtblin/kube2iam/issues/44

Hey - just raising this as a *possible* simple answer to the issue around kube2iam not cleaning up after itself and removing iptables rules on exit. Judging from the debate perhaps this is behaviour the users should configure depending on their security requirements?

I think this is something that should be addressed one way or another (even if not through this pr!) as there are real world scenarios where you might need to abort/roll back a deploy of kube2iam without leaving your cluster unable to access ec2 metadata, or perhaps reconfigure it to use another port etc without wanting to manually remove iptables rules. 