### PR TITLE
Optionally revert iptables changes on exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ORG_PATH="github.com/jtblin"
+ORG_PATH ?= "github.com/jtblin"
 BINARY_NAME := kube2iam
 REPO_PATH="$(ORG_PATH)/$(BINARY_NAME)"
 VERSION_VAR := $(REPO_PATH)/version.Version
@@ -27,10 +27,10 @@ setup:
 	glide install --strip-vendor
 
 build: *.go fmt
-	go build -o build/bin/$(ARCH)/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) github.com/jtblin/$(BINARY_NAME)/cmd
+	go build -o build/bin/$(ARCH)/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) $(ORG_PATH)/$(BINARY_NAME)/cmd
 
 build-race: *.go fmt
-	go build -race -o build/bin/$(ARCH)/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) github.com/jtblin/$(BINARY_NAME)/cmd
+	go build -race -o build/bin/$(ARCH)/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) $(ORG_PATH)/$(BINARY_NAME)/cmd
 
 build-all:
 	go build $$(glide nv)
@@ -79,7 +79,7 @@ watch:
 	CompileDaemon -color=true -build "make test"
 
 cross:
-	CGO_ENABLED=0 GOOS=linux go build -o build/bin/linux/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) -a -installsuffix cgo  github.com/jtblin/$(BINARY_NAME)/cmd
+	CGO_ENABLED=0 GOOS=linux go build -o build/bin/linux/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) -a -installsuffix cgo  $(ORG_PATH)/$(BINARY_NAME)/cmd
 
 docker: cross
 	docker build -t $(IMAGE_NAME):$(GIT_HASH) . $(DOCKER_BUILD_FLAGS)

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Usage of ./build/bin/darwin/kube2iam:
       --iam-role-key string                 Pod annotation key used to retrieve the IAM role (default "iam.amazonaws.com/role")
       --insecure                            Kubernetes server should be accessed without verifying the TLS. Testing only
       --iptables                            Add iptables rule (also requires --host-ip)
+      --remove-iptables-on-exit             Attempt to remove iptables rule on exit (also requires --iptables)
       --log-level string                    Log level (default "info")
       --metadata-addr string                Address for the ec2 metadata (default "169.254.169.254")
       --namespace-key string                Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array) (default "iam.amazonaws.com/allowed-roles")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,18 +1,17 @@
 package main
 
 import (
+	"os"
+	"os/signal"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
+	"syscall"
 
 	"github.com/jtblin/kube2iam/iam"
 	"github.com/jtblin/kube2iam/iptables"
 	"github.com/jtblin/kube2iam/server"
 	"github.com/jtblin/kube2iam/version"
-	"os"
-	"os/signal"
-	"syscall"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 )
 
 // addFlags adds the command line flags.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,9 @@ import (
 	"github.com/jtblin/kube2iam/iptables"
 	"github.com/jtblin/kube2iam/server"
 	"github.com/jtblin/kube2iam/version"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 // addFlags adds the command line flags.
@@ -24,6 +27,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.Insecure, "insecure", false, "Kubernetes server should be accessed without verifying the TLS. Testing only")
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the ec2 metadata")
 	fs.BoolVar(&s.AddIPTablesRule, "iptables", false, "Add iptables rule (also requires --host-ip)")
+	fs.BoolVar(&s.RemoveIPTablesRuleOnExit, "remove-iptables-on-exit", false, "Attempt to remove iptables rule on exit (also requires --iptables)")
 	fs.BoolVar(&s.AutoDiscoverBaseArn, "auto-discover-base-arn", false, "Queries EC2 Metadata to determine the base ARN")
 	fs.BoolVar(&s.AutoDiscoverDefaultRole, "auto-discover-default-role", false, "Queries EC2 Metadata to determine the default Iam Role and base ARN, cannot be used with --default-role, overwrites any previous setting for --base-role-arn")
 	fs.StringVar(&s.HostInterface, "host-interface", "docker0", "Host interface for proxying AWS metadata")
@@ -99,9 +103,24 @@ func main() {
 		if err := iptables.AddRule(s.AppPort, s.MetadataAddress, s.HostInterface, s.HostIP); err != nil {
 			log.Fatalf("%s", err)
 		}
+	} else if s.RemoveIPTablesRuleOnExit {
+		log.Fatalf("You cannot use --remove-iptables-on-exit without also specifying --iptables")
 	}
 
-	if err := s.Run(s.APIServer, s.APIToken, s.Insecure); err != nil {
-		log.Fatalf("%s", err)
+	signalChan := make(chan os.Signal)
+	go func() {
+		if err := s.Run(s.APIServer, s.APIToken, s.Insecure); err != nil {
+			log.Errorf("%s", err)
+			signalChan <- syscall.SIGABRT // On error, just quit now by faking a signal
+		}
+	}()
+
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+	<-signalChan
+
+	if s.RemoveIPTablesRuleOnExit {
+		if err := iptables.DeleteRule(s.AppPort, s.MetadataAddress, s.HostInterface, s.HostIP); err != nil {
+			log.Errorf("%s", err)
+		}
 	}
 }


### PR DESCRIPTION
Referencing #44 

Hey - just raising this as a possible simple answer to the issue around kube2iam not cleaning up after itself and removing iptables rules on exit. Judging from the debate perhaps this is behaviour the users should configure depending on their security requirements?

I think this is something that should be addressed one way or another (even if not through this pr!) as there are real world scenarios where you might need to abort/roll back a deploy of kube2iam without leaving your cluster unable to access ec2 metadata, or perhaps reconfigure it to use another interface or port etc without wanting to manually remove iptables rules.

ps please ignore my other closed pr for this same issue, that was opened prematurely !