### PR TITLE
Offer pod namespace and name for validation when assuming role

### DIFF
--- a/iam/iam.go
+++ b/iam/iam.go
@@ -73,7 +73,7 @@ func sessionName(roleARN, remoteIP string) string {
 }
 
 // AssumeRole returns an IAM role Credentials using AWS STS.
-func (iam *Client) AssumeRole(roleARN, remoteIP string) (*Credentials, error) {
+func (iam *Client) AssumeRole(roleARN, remoteIP string, externalID string) (*Credentials, error) {
 	item, err := cache.Fetch(roleARN, ttl, func() (interface{}, error) {
 		sess, err := session.NewSession()
 		if err != nil {
@@ -84,6 +84,7 @@ func (iam *Client) AssumeRole(roleARN, remoteIP string) (*Credentials, error) {
 			DurationSeconds: aws.Int64(int64(ttl.Seconds() * 2)),
 			RoleArn:         aws.String(roleARN),
 			RoleSessionName: aws.String(sessionName(roleARN, remoteIP)),
+			ExternalId:      aws.String(externalID),
 		})
 		if err != nil {
 			return nil, err

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -33,6 +33,7 @@ type RoleMappingResult struct {
 	Role      string
 	IP        string
 	Namespace string
+	Name      string
 }
 
 // GetRoleMapping returns the normalized iam RoleMappingResult based on IP address
@@ -50,7 +51,7 @@ func (r *RoleMapper) GetRoleMapping(IP string) (*RoleMappingResult, error) {
 
 	// Determine if normalized role is allowed to be used in pod's namespace
 	if r.checkRoleForNamespace(role, pod.GetNamespace()) {
-		return &RoleMappingResult{Role: role, Namespace: pod.GetNamespace(), IP: IP}, nil
+		return &RoleMappingResult{Role: role, Namespace: pod.GetNamespace(), Name: pod.GetName(), IP: IP}, nil
 	}
 
 	return nil, fmt.Errorf("Role requested %s not valid for namespace of pod at %s with namespace %s", role, IP, pod.GetNamespace())

--- a/server/server.go
+++ b/server/server.go
@@ -219,6 +219,7 @@ func (s *Server) roleHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 	}
 
 	roleLogger := logger.WithFields(log.Fields{
+		"pod.name":     roleMapping.Name,
 		"pod.iam.role": roleMapping.Role,
 		"ns.name":      roleMapping.Namespace,
 	})
@@ -233,7 +234,8 @@ func (s *Server) roleHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	credentials, err := s.iam.AssumeRole(wantedRoleARN, remoteIP)
+	externalID := fmt.Sprintf("kube2iam/%s/%s", roleMapping.Namespace, roleMapping.Name)
+	credentials, err := s.iam.AssumeRole(wantedRoleARN, remoteIP, externalID)
 	if err != nil {
 		roleLogger.Errorf("Error assuming role %+v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Running kube2iam in a multi-tenant setup, also connected to multiple AWS accounts, I thought it would be useful to offer the pod's namespace and name up for validation on the AWS IAM side as well. This could be extended to include some secret value in place of the `kube2iam/` prefix, but I thought I'd share early and ask for feedback on this feature.

In the default case, where no conditions on the `ExternalId` have been configured, this is harmless metadata that may be logged in CloudTrail.