### PR TITLE
Update alpine to 3.7 to address vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 RUN apk --no-cache add \
     ca-certificates \


### PR DESCRIPTION
## what

Update alpine to 3.7

## why

alpine 3.6 contains the following vulnerabilities:

- musl: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-15650
- busybox: https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-16544 and https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-15873