### PR TITLE
Add amazon-vpc-cni-k8s to the host-interface examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ different than `docker0` depending on which virtual network you use e.g.
 * for Calico, use `cali+` (the interface name is something like cali1234567890
 * for kops (on kubenet), use `cbr0`
 * for CNI, use `cni0`
+* for [amazon-vpc-cni-k8s](https://github.com/aws/amazon-vpc-cni-k8s), use `eni+`. (Each pod gets an interface like `eni4c0e15dfb05`)
 * for weave use `weave`
 * for flannel use `cni0`
 * for [kube-router](https://github.com/cloudnativelabs/kube-router) use `kube-bridge`


### PR DESCRIPTION
Adds instructions for `amazon-vpc-cni-k8s` which is the default in the recently released EKS service.

Not sure if it needs more explanation around it being in EKS, as EKS users may come here looking for help.