### PR TITLE
Update README.md to mention interface for Cilium

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ different than `docker0` depending on which virtual network you use e.g.
 * for weave use `weave`
 * for flannel use `cni0`
 * for [kube-router](https://github.com/cloudnativelabs/kube-router) use `kube-bridge`
+* for [Cilium](https://www.cilium.io) use `lxc+`
 
 ```yaml
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
The README.md currently include instructions for what interface name/regex to use when configuring kube2iam with various Kubernetes networking solutions.   This change follows the existing format and adds those instructions for http://www.cilium.io based on a question asked on the Cilium slack channel.  The user validated that this configuration works with kube2iam w/Cilium.