### PR TITLE
Amazon EKS Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ different than `docker0` depending on which virtual network you use e.g.
 * for [kube-router](https://github.com/cloudnativelabs/kube-router) use `kube-bridge`
 * for [OpenShift](https://www.openshift.org/) use `tun0`
 * for [Cilium](https://www.cilium.io) use `lxc+`
+* for [Amazon EKS](https://aws.amazon.com/eks) use `eni+`
 
 ```yaml
 apiVersion: apps/v1


### PR DESCRIPTION
For kube2iam to work on Amazon EKS, you need to update the interface to eni+. Many people will be looking for this information and I believe this should be explicit in the documentation.