### PR TITLE
Avoid the following error: `ValidationError(DaemonSet.spec)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ metadata:
   labels:
     app: kube2iam
 spec:
+  selector:
+    matchLabels:
+      name: kube2iam
   template:
     metadata:
       labels:
@@ -155,6 +158,9 @@ metadata:
   labels:
     app: kube2iam
 spec:
+  selector:
+    matchLabels:
+      name: kube2iam
   template:
     metadata:
       labels:
@@ -355,6 +361,9 @@ metadata:
   labels:
     app: kube2iam
 spec:
+  selector:
+    matchLabels:
+      name: kube2iam
   template:
     metadata:
       labels:


### PR DESCRIPTION
According to the [docs](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
> As of Kubernetes 1.8, you must specify a pod selector that matches the labels of the .spec.template. The pod selector will no longer be defaulted when left empty.

Without these changes, the following error is seen:
`error: error validating "kube2iam.yaml": error validating data: ValidationError(DaemonSet.spec): missing required field "selector" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false`

Adding these changes satisfies validation.