### PR TITLE
Add Documentation & Example For EKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,12 @@ different than `docker0` depending on which virtual network you use e.g.
 * for Calico, use `cali+` (the interface name is something like cali1234567890
 * for kops (on kubenet), use `cbr0`
 * for CNI, use `cni0`
-* for [amazon-vpc-cni-k8s](https://github.com/aws/amazon-vpc-cni-k8s), use `eni+`. (Each pod gets an interface like `eni4c0e15dfb05`)
+* for [EKS](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html)/[amazon-vpc-cni-k8s](https://github.com/aws/amazon-vpc-cni-k8s), use `eni+`. (Each pod gets an interface like `eni4c0e15dfb05`)
 * for weave use `weave`
 * for flannel use `cni0`
 * for [kube-router](https://github.com/cloudnativelabs/kube-router) use `kube-bridge`
 * for [OpenShift](https://www.openshift.org/) use `tun0`
 * for [Cilium](https://www.cilium.io) use `lxc+`
-* for [EKS](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html) use `eni+`
 
 ```yaml
 apiVersion: apps/v1

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ different than `docker0` depending on which virtual network you use e.g.
 * for [kube-router](https://github.com/cloudnativelabs/kube-router) use `kube-bridge`
 * for [OpenShift](https://www.openshift.org/) use `tun0`
 * for [Cilium](https://www.cilium.io) use `lxc+`
+* for [EKS](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html) use `eni+`
 
 ```yaml
 apiVersion: apps/v1

--- a/examples/eks-example.yml
+++ b/examples/eks-example.yml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube2iam
+  namespace: kube-system
+---
+apiVersion: v1
+items:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kube2iam
+    rules:
+      - apiGroups: [""]
+        resources: ["namespaces","pods"]
+        verbs: ["get","watch","list"]
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kube2iam
+    subjects:
+    - kind: ServiceAccount
+      name: kube2iam
+      namespace: kube-system
+    roleRef:
+      kind: ClusterRole
+      name: kube2iam
+      apiGroup: rbac.authorization.k8s.io
+kind: List
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube2iam
+  namespace: kube-system
+  labels:
+    app: kube2iam
+spec:
+  selector:
+    matchLabels:
+      name: kube2iam
+  template:
+    metadata:
+      labels:
+        name: kube2iam
+    spec:
+      serviceAccountName: kube2iam
+      hostNetwork: true
+      containers:
+        - image: jtblin/kube2iam:latest
+          imagePullPolicy: Always
+          name: kube2iam
+          args:
+            - "--auto-discover-base-arn"
+            - "--auto-discover-default-role=true"
+            - "--iptables=true"
+            - "--host-ip=$(HOST_IP)"
+            - "--node=$(NODE_NAME)"
+            - "--host-interface=eni+"
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 8181
+              hostPort: 8181
+              name: http
+          securityContext:
+            privileged: true


### PR DESCRIPTION
While setting up kube2iam on my EKS cluster I struggled to get the service working until someone in the k8s slack  generously donated an hour of their time to help me debug it.
To facilitate faster setup for EKS users in the future I've added the following two changes
* Correct host interface for a default EKS cluster
* Example eks yaml file that is generic for EKS users and can be generally extended from the other documentation in the README