### PR TITLE
Add new flags for session TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@ Usage of kube2iam:
       --backoff-max-elapsed-time duration     Max elapsed time for backoff when querying for role. (default 2s)
       --backoff-max-interval duration         Max interval for backoff when querying for role. (default 1s)
       --base-role-arn string                  Base role ARN
+      --iam-role-session-ttl                  Length of session when assuming the roles (default 15m)
       --debug                                 Enable debug features
       --default-role string                   Fallback role to use when annotation is not set
       --host-interface string                 Host interface for proxying AWS metadata (default "docker0")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.Debug, "debug", s.Debug, "Enable debug features")
 	fs.StringVar(&s.DefaultIAMRole, "default-role", s.DefaultIAMRole, "Fallback role to use when annotation is not set")
 	fs.StringVar(&s.IAMRoleKey, "iam-role-key", s.IAMRoleKey, "Pod annotation key used to retrieve the IAM role")
+	fs.DurationVar(&s.IAMRoleSessionTTL, "iam-role-session-ttl", s.IAMRoleSessionTTL, "TTL for the assume role session")
 	fs.BoolVar(&s.Insecure, "insecure", false, "Kubernetes server should be accessed without verifying the TLS. Testing only")
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the ec2 metadata")
 	fs.BoolVar(&s.AddIPTablesRule, "iptables", false, "Add iptables rule (also requires --host-ip)")

--- a/server/server.go
+++ b/server/server.go
@@ -31,6 +31,7 @@ const (
 	defaultLogLevel                   = "info"
 	defaultLogFormat                  = "text"
 	defaultMaxElapsedTime             = 2 * time.Second
+	defaultIAMRoleSessionTTL          = 15 * time.Minute
 	defaultMaxInterval                = 1 * time.Second
 	defaultMetadataAddress            = "169.254.169.254"
 	defaultNamespaceKey               = "iam.amazonaws.com/allowed-roles"
@@ -51,6 +52,7 @@ type Server struct {
 	BaseRoleARN                string
 	DefaultIAMRole             string
 	IAMRoleKey                 string
+	IAMRoleSessionTTL          time.Duration
 	MetadataAddress            string
 	HostInterface              string
 	HostIP                     string
@@ -309,7 +311,7 @@ func (s *Server) roleHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	credentials, err := s.iam.AssumeRole(wantedRoleARN, remoteIP)
+	credentials, err := s.iam.AssumeRole(wantedRoleARN, remoteIP, s.IAMRoleSessionTTL)
 	if err != nil {
 		roleLogger.Errorf("Error assuming role %+v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -406,5 +408,6 @@ func NewServer() *Server {
 		NamespaceKey:               defaultNamespaceKey,
 		NamespaceRestrictionFormat: defaultNamespaceRestrictionFormat,
 		HealthcheckFailReason:      "Healthcheck not yet performed",
+		IAMRoleSessionTTL:          defaultIAMRoleSessionTTL,
 	}
 }


### PR DESCRIPTION
We have long-running applications with pre-signed urls for videos. With a hard-coded 15mins TTL, videos would break, or if we did a re-sign + re-render, it would reset the video.

This PR adds a flag for the user to control the session TTL. 