### PR TITLE
allow use of sts regional endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ You can use `--default-role` to set a fallback role to use when annotation is no
 
 #### ReplicaSet, CronJob, Deployment, etc.
 
-When creating higher-level abstractions than pods, you need to pass the annotation in the pod template of the  
+When creating higher-level abstractions than pods, you need to pass the annotation in the pod template of the
 resource spec.
 
 Example for a `Deployment`:
@@ -287,10 +287,10 @@ metadata:
   name: default
 ```
 
-_Note:_ You can also use glob-based matching for namespace restrictions, which works nicely with the path-based 
+_Note:_ You can also use glob-based matching for namespace restrictions, which works nicely with the path-based
 namespacing supported for AWS IAM roles.
 
-Example: to allow all roles prefixed with `my-custom-path/` to be assumed by pods in the default namespace, the 
+Example: to allow all roles prefixed with `my-custom-path/` to be assumed by pods in the default namespace, the
 default namespace would be annotated as follows:
 
 ```yaml
@@ -518,6 +518,12 @@ By using the `--auto-discover-base-arn` flag, kube2iam will auto discover the ba
 By using the `--auto-discover-default-role` flag, kube2iam will auto discover the base ARN and the IAM role attached to
 the instance and use it as the fallback role to use when annotation is not set.
 
+### AWS STS Endpoint and Regions
+
+STS is a unique service in that it is actually considered a global service that defaults to endpoint at **https://sts.amazonaws.com**, regardless of your region setting. However, unlike other global services (e.g. CloudFront, IAM), STS also has regional endpoints which can only be explicitly used programatically. The use of a regional sts endpoint can reduce the latency for STS requests.
+
+`kube2iam` supports the use of STS regional endpoints by using the `--use-regional-sts-endpoint` flag as well as by setting the appropriate `AWS_REGION` environment variable in your daemonset environment. With these two settings configured, `kube2iam` will use the STS api endpoint for that region. If you enable debug level logging, the sts endpoint used to retrieve credentials will be logged.
+
 ### Options
 
 By default, `kube2iam` will use the in-cluster method to connect to the kubernetes master, and use the
@@ -527,29 +533,32 @@ ARN in the annotation.
 
 ```bash
 $ kube2iam --help
-Usage of ./build/bin/darwin/kube2iam:
-      --api-server string                   Endpoint for the api server
-      --api-token string                    Token to authenticate with the api server
-      --app-port string                     Http port (default "8181")
-      --auto-discover-base-arn              Queries EC2 Metadata to determine the base ARN
-      --auto-discover-default-role          Queries EC2 Metadata to determine the default Iam Role and base ARN, cannot be used with --default-role, overwrites any previous setting for --base-role-arn
-      --backoff-max-elapsed-time duration   Max elapsed time for backoff when querying for role. (default 2s)
-      --backoff-max-interval duration       Max interval for backoff when querying for role. (default 1s)
-      --base-role-arn string                Base role ARN
-      --debug                               Enable debug features
-      --default-role string                 Fallback role to use when annotation is not set
-      --host-interface string               Host interface for proxying AWS metadata (default "docker0")
-      --host-ip string                      IP address of host
-      --iam-role-key string                 Pod annotation key used to retrieve the IAM role (default "iam.amazonaws.com/role")
-      --insecure                            Kubernetes server should be accessed without verifying the TLS. Testing only
-      --iptables                            Add iptables rule (also requires --host-ip)
-      --log-format string                   Log format (text/json) (default "text")
-      --log-level string                    Log level (default "info")
-      --metadata-addr string                Address for the ec2 metadata (default "169.254.169.254")
-      --namespace-key string                Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array) (default "iam.amazonaws.com/allowed-roles")
-      --namespace-restrictions              Enable namespace restrictions
-      --verbose                             Verbose
-      --version                             Print the version and exits
+Usage of kube2iam:
+      --api-server string                     Endpoint for the api server
+      --api-token string                      Token to authenticate with the api server
+      --app-port string                       Http port (default "8181")
+      --auto-discover-base-arn                Queries EC2 Metadata to determine the base ARN
+      --auto-discover-default-role            Queries EC2 Metadata to determine the default Iam Role and base ARN, cannot be used with --default-role, overwrites any previous setting for --base-role-arn
+      --backoff-max-elapsed-time duration     Max elapsed time for backoff when querying for role. (default 2s)
+      --backoff-max-interval duration         Max interval for backoff when querying for role. (default 1s)
+      --base-role-arn string                  Base role ARN
+      --debug                                 Enable debug features
+      --default-role string                   Fallback role to use when annotation is not set
+      --host-interface string                 Host interface for proxying AWS metadata (default "docker0")
+      --host-ip string                        IP address of host
+      --iam-role-key string                   Pod annotation key used to retrieve the IAM role (default "iam.amazonaws.com/role")
+      --insecure                              Kubernetes server should be accessed without verifying the TLS. Testing only
+      --iptables                              Add iptables rule (also requires --host-ip)
+      --log-format string                     Log format (text/json) (default "text")
+      --log-level string                      Log level (default "info")
+      --metadata-addr string                  Address for the ec2 metadata (default "169.254.169.254")
+      --namespace-key string                  Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array) (default "iam.amazonaws.com/allowed-roles")
+      --namespace-restriction-format string   Namespace Restriction Format (glob/regexp) (default "glob")
+      --namespace-restrictions                Enable namespace restrictions
+      --node string                           Name of the node where kube2iam is running
+      --use-regional-sts-endpoint             use the regional sts endpoint if AWS_REGION is set
+      --verbose                               Verbose
+      --version                               Print the version and exits
 ```
 
 ## Development loop

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.DurationVar(&s.BackoffMaxElapsedTime, "backoff-max-elapsed-time", s.BackoffMaxElapsedTime, "Max elapsed time for backoff when querying for role.")
 	fs.StringVar(&s.LogFormat, "log-format", s.LogFormat, "Log format (text/json)")
 	fs.StringVar(&s.LogLevel, "log-level", s.LogLevel, "Log level")
+	fs.BoolVar(&s.UseRegionalStsEndpoint, "use-regional-sts-endpoint", false, "use the regional sts endpoint if AWS_REGION is set")
 	fs.BoolVar(&s.Verbose, "verbose", false, "Verbose")
 	fs.BoolVar(&s.Version, "version", false, "Print the version and exits")
 }

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -77,6 +77,17 @@ func sessionName(roleARN, remoteIP string) string {
 	return fmt.Sprintf("%.[2]*[1]s", name, maxSessNameLength)
 }
 
+// Helper to format IAM return codes for metric labeling
+func getIAMCode(err error) string {
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			return awsErr.Code()
+		}
+		return metrics.IamUnknownFailCode
+	}
+	return metrics.IamSuccessCode
+}
+
 // GetEndpointFromRegion formas a standard sts endpoint url given a region
 func GetEndpointFromRegion(region string) string {
 	endpoint := fmt.Sprintf("https://sts.%s.amazonaws.com", region)
@@ -113,16 +124,6 @@ func (iam *Client) EndpointFor(service, region string, optFns ...func(*endpoints
 		}
 	}
 	return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
-
-// Helper to format IAM return codes for metric labeling
-func getIAMCode(err error) string {
-	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			return awsErr.Code()
-		}
-		return metrics.IamUnknownFailCode
-	}
-	return metrics.IamSuccessCode
 }
 
 // AssumeRole returns an IAM role Credentials using AWS STS.

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -1,0 +1,44 @@
+package iam
+
+import (
+	"testing"
+)
+
+func TestIsValidRegion(t *testing.T) {
+	regions := []string{
+		"eu-central-1",
+		"eu-west-1",
+		"eu-west-2",
+		"ap-southeast-2",
+		"ap-south-1",
+		"sa-east-1",
+		"ca-central-1",
+		"ap-northeast-1",
+		"us-east-1",
+		"us-west-2",
+		"us-east-2",
+		"ap-northeast-2",
+		"ap-southeast-1",
+		"us-west-1",
+		"cn-north-1",
+		"us-gov-west-1",
+	}
+	for _, region := range regions {
+		if !IsValidRegion(region) {
+			t.Errorf("%s is not a valid region", region)
+		}
+	}
+}
+
+func TestIsValidRegionWithInvalid(t *testing.T) {
+	regions := []string{
+		"cn-north-7",
+		"",
+		"xx-xxxx-x",
+	}
+	for _, region := range regions {
+		if IsValidRegion(region) {
+			t.Errorf("%s is a valid region", region)
+		}
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -53,6 +53,7 @@ type Server struct {
 	LogLevel                   string
 	LogFormat                  string
 	NamespaceRestrictionFormat string
+	UseRegionalStsEndpoint     bool
 	AddIPTablesRule            bool
 	AutoDiscoverBaseArn        bool
 	AutoDiscoverDefaultRole    bool
@@ -244,6 +245,7 @@ func (s *Server) roleHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	roleLogger.Debugf("retrieved credentials from sts endpoint: %s", s.iam.Endpoint)
 
 	if err := json.NewEncoder(w).Encode(credentials); err != nil {
 		roleLogger.Errorf("Error sending json %+v", err)
@@ -270,7 +272,8 @@ func (s *Server) Run(host, token, nodeName string, insecure bool) error {
 		return err
 	}
 	s.k8s = k
-	s.iam = iam.NewClient(s.BaseRoleARN)
+	s.iam = iam.NewClient(s.BaseRoleARN, s.UseRegionalStsEndpoint)
+	log.Debugln("Caches have been synced.  Proceeding with server.")
 	s.roleMapper = mappings.NewRoleMapper(s.IAMRoleKey, s.DefaultIAMRole, s.NamespaceRestriction, s.NamespaceKey, s.iam, s.k8s, s.NamespaceRestrictionFormat)
 	podSynched := s.k8s.WatchForPods(kube2iam.NewPodHandler(s.IAMRoleKey))
 	namespaceSynched := s.k8s.WatchForNamespaces(kube2iam.NewNamespaceHandler(s.NamespaceKey))


### PR DESCRIPTION
This one addresses #164 and allows the use of regional sts api endpoints instead of the default us-east-1 based endpoint. 

For users in regions other than us-east-1 this should mean slightly reduced latency in sts api calls.

By default the aws sdk will resolve the sts endpoint to `sts.amazonaws.com` as described [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html#sts-regionalization). The regional api endpoint can only be set programmatically. Setting region via code or environment does not affect the endpoint, as indirectly described [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#id_credentials_temp_enable-regions_writing_code).

To enable the use of this feature, a boolean flag `--use-regional-sts-endpoint` must be used in conjunction with the appropriately set environment variable `AWS_REGION`.  The use of a flag will mean no impact to existing users' deployments.
