### PR TITLE
use %f instead of %d for latency logging

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -141,7 +141,7 @@ func (h *appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	latencyNanoseconds := timeSecs * 1e9
 	if r.URL.Path != "/healthz" {
 		logger.WithFields(log.Fields{"res.duration": latencyNanoseconds, "res.status": rw.statusCode}).
-			Infof("%s %s (%d) took %d ns", r.Method, r.URL.Path, rw.statusCode, latencyNanoseconds)
+			Infof("%s %s (%d) took %f ns", r.Method, r.URL.Path, rw.statusCode, latencyNanoseconds)
 	}
 }
 


### PR DESCRIPTION
`latencyNanoseconds` is a `float64` so the appropriate format is `%f` instead of `%d`. This will make the log line a bit more clear since it currently looks like this:

```
msg="GET /latest/meta-data/iam/security-credentials/foo (200) took %!d(float64=118126) ns"
```