### PR TITLE
Change ADD to COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apk --no-cache add \
     ca-certificates \
     iptables
 
-ADD build/bin/linux/kube2iam /bin/kube2iam
+COPY build/bin/linux/kube2iam /bin/kube2iam
 
 ENTRYPOINT ["kube2iam"]


### PR DESCRIPTION
ADD is reserved for pulling in and automatically unpacking .tar/.gz files
COPY is for copying files across, which is what you're trying to achieve.