### PR TITLE
Allow pods being terminated to get credentials

### DIFF
--- a/pod.go
+++ b/pod.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -71,10 +72,14 @@ func (p *PodHandler) OnDelete(obj interface{}) {
 }
 
 func isPodActive(p *v1.Pod) bool {
+	podDeleted := false
+	if p.DeletionTimestamp != nil {
+		podDeleted = p.DeletionTimestamp.Before(unversioned.Now())
+	}
 	return p.Status.PodIP != "" &&
 		v1.PodSucceeded != p.Status.Phase &&
 		v1.PodFailed != p.Status.Phase &&
-		p.DeletionTimestamp == nil
+		!podDeleted
 }
 
 // PodIPIndexFunc maps a given Pod to it's IP for caching.


### PR DESCRIPTION
When a pod is deleted, the containers are issued a `SIGTERM` and its `deletionTimestamp` is set to now + `terminationGracePeriodSeconds`. After that time, a `SIGKILL` is issued and the pod is deleted (see [deletionTimestamp](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectmeta-v1-meta)).

For pods with longer terminationGracePeriodSeconds, its possible for the container process to refresh its credentials after the `SIGTERM` but before the `SIGKILL`. Prior to this PR, credentials were not provided and the process' cleanup would fail. This PR allows containers in the process of shutting down to refresh their credentials.

Fixes #172 

This means that we're now relying on the client's clock to be in sync with the master's clock but I would assume that is already a reasonable requirement for functioning Kubernetes clusters.


To test:

```sh
#!/bin/bash
# script.sh

trap "echo got shutdown" SIGTERM

while :
do
  sleep 1
done
```

```dockerfile
FROM mesosphere/aws-cli:latest

ADD script.sh /script.sh

ENTRYPOINT ["sh", "/script.sh"]
```

Run a pod with that image and an IAM role annotation. `kubectl exec` into the pod and repeatedly run `aws sts get-caller-identity` and observe the result. `kubectl delete` the pod. The credentials will continue to be fetched until the pod is terminated.