### PR TITLE
Add support for sts external-id authentication

### DIFF
--- a/iam/iam.go
+++ b/iam/iam.go
@@ -126,7 +126,7 @@ func (iam *Client) EndpointFor(service, region string, optFns ...func(*endpoints
 }
 
 // AssumeRole returns an IAM role Credentials using AWS STS.
-func (iam *Client) AssumeRole(roleARN, externalId string, remoteIP string, sessionTTL time.Duration) (*Credentials, error) {
+func (iam *Client) AssumeRole(roleARN, externalID string, remoteIP string, sessionTTL time.Duration) (*Credentials, error) {
 	hitCache := true
 	item, err := cache.Fetch(roleARN, sessionTTL, func() (interface{}, error) {
 		hitCache = false
@@ -154,8 +154,8 @@ func (iam *Client) AssumeRole(roleARN, externalId string, remoteIP string, sessi
 			RoleArn:         aws.String(roleARN),
 			RoleSessionName: aws.String(sessionName(roleARN, remoteIP)),
 		}
-		if externalId != "" {
-			assumeRoleInput.ExternalId = aws.String(externalId)
+		if externalID != "" {
+			assumeRoleInput.ExternalId = aws.String(externalID)
 		}
 
 		resp, err := svc.AssumeRole(assumeRoleInput)

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -126,7 +126,7 @@ func (iam *Client) EndpointFor(service, region string, optFns ...func(*endpoints
 }
 
 // AssumeRole returns an IAM role Credentials using AWS STS.
-func (iam *Client) AssumeRole(roleARN, remoteIP string, sessionTTL time.Duration) (*Credentials, error) {
+func (iam *Client) AssumeRole(roleARN, externalId string, remoteIP string, sessionTTL time.Duration) (*Credentials, error) {
 	hitCache := true
 	item, err := cache.Fetch(roleARN, sessionTTL, func() (interface{}, error) {
 		hitCache = false
@@ -149,11 +149,16 @@ func (iam *Client) AssumeRole(roleARN, remoteIP string, sessionTTL time.Duration
 			config = config.WithEndpointResolver(iam)
 		}
 		svc := sts.New(sess, config)
-		resp, err := svc.AssumeRole(&sts.AssumeRoleInput{
+		assumeRoleInput := &sts.AssumeRoleInput{
 			DurationSeconds: aws.Int64(int64(sessionTTL.Seconds() * 2)),
 			RoleArn:         aws.String(roleARN),
 			RoleSessionName: aws.String(sessionName(roleARN, remoteIP)),
-		})
+		}
+		if externalId != "" {
+			assumeRoleInput.ExternalId = aws.String(externalId)
+		}
+
+		resp, err := svc.AssumeRole(assumeRoleInput)
 		if err != nil {
 			return nil, err
 		}

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -53,18 +53,15 @@ func (r *RoleMapper) GetRoleMapping(IP string) (*RoleMappingResult, error) {
 		return nil, err
 	}
 
-	externalID, err := r.extractExternalID(pod)
-	if err != nil {
-		return nil, err
-	}
+	externalID := r.extractExternalID(pod)
 
 // Determine if normalized role is allowed to be used in pod's namespace
 	if r.checkRoleForNamespace(role, pod.GetNamespace()) {
 		return &RoleMappingResult{
-			Role: role,
+			Role:       role,
 			ExternalID: externalID,
-			Namespace: pod.GetNamespace(),
-			IP: IP,
+			Namespace:  pod.GetNamespace(),
+			IP:         IP,
 		}, nil
 	}
 
@@ -90,7 +87,7 @@ func (r *RoleMapper) extractRoleARN(pod *v1.Pod) (string, error) {
 }
 
 // extractExternalID extracts the external id string if it's there, defaults to ""
-func (r *RoleMapper) extractExternalID(pod *v1.Pod) (string, error) {
+func (r *RoleMapper) extractExternalID(pod *v1.Pod) string {
 	rawExternalID, annotationPresent := pod.GetAnnotations()[r.externalIDKey]
 
 	if !annotationPresent {
@@ -98,7 +95,7 @@ func (r *RoleMapper) extractExternalID(pod *v1.Pod) (string, error) {
 		rawExternalID = ""
 	}
 
-	return rawExternalID, nil
+	return rawExternalID
 }
 
 // checkRoleForNamespace checks the 'database' for a role allowed in a namespace,

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -17,7 +17,7 @@ import (
 type RoleMapper struct {
 	defaultRoleARN             string
 	iamRoleKey                 string
-	externalID                 string
+	externalIDKey              string
 	namespaceKey               string
 	namespaceRestriction       bool
 	iam                        *iam.Client
@@ -58,7 +58,7 @@ func (r *RoleMapper) GetRoleMapping(IP string) (*RoleMappingResult, error) {
 		return nil, err
 	}
 
-	// Determine if normalized role is allowed to be used in pod's namespace
+// Determine if normalized role is allowed to be used in pod's namespace
 	if r.checkRoleForNamespace(role, pod.GetNamespace()) {
 		return &RoleMappingResult{
 			Role: role,
@@ -91,7 +91,7 @@ func (r *RoleMapper) extractRoleARN(pod *v1.Pod) (string, error) {
 
 // extractExternalID extracts the external id string if it's there, defaults to ""
 func (r *RoleMapper) extractExternalID(pod *v1.Pod) (string, error) {
-	rawExternalID, annotationPresent := pod.GetAnnotations()[r.externalID]
+	rawExternalID, annotationPresent := pod.GetAnnotations()[r.externalIDKey]
 
 	if !annotationPresent {
 		log.Debug("Defaulting external ID to empty string, will be ignored in sts.AssumeRole")
@@ -171,11 +171,11 @@ func (r *RoleMapper) DumpDebugInfo() map[string]interface{} {
 }
 
 // NewRoleMapper returns a new RoleMapper for use.
-func NewRoleMapper(roleKey string, externalID string, defaultRole string, namespaceRestriction bool, namespaceKey string, iamInstance *iam.Client, kubeStore store, namespaceRestrictionFormat string) *RoleMapper {
+func NewRoleMapper(roleKey string, externalIDKey string, defaultRole string, namespaceRestriction bool, namespaceKey string, iamInstance *iam.Client, kubeStore store, namespaceRestrictionFormat string) *RoleMapper {
 	return &RoleMapper{
 		defaultRoleARN:             iamInstance.RoleARN(defaultRole),
 		iamRoleKey:                 roleKey,
-		externalID:                 externalID,
+		externalIDKey:              externalIDKey,
 		namespaceKey:               namespaceKey,
 		namespaceRestriction:       namespaceRestriction,
 		iam:                        iamInstance,

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -17,7 +17,7 @@ import (
 type RoleMapper struct {
 	defaultRoleARN             string
 	iamRoleKey                 string
-	externalId                 string
+	externalID                 string
 	namespaceKey               string
 	namespaceRestriction       bool
 	iam                        *iam.Client
@@ -35,7 +35,7 @@ type store interface {
 // RoleMappingResult represents the relevant information for a given mapping request
 type RoleMappingResult struct {
 	Role       string
-	ExternalId string
+	ExternalID string
 	IP         string
 	Namespace  string
 }
@@ -53,7 +53,7 @@ func (r *RoleMapper) GetRoleMapping(IP string) (*RoleMappingResult, error) {
 		return nil, err
 	}
 
-	externalId, err := r.extractExternalId(pod)
+	externalID, err := r.extractExternalID(pod)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (r *RoleMapper) GetRoleMapping(IP string) (*RoleMappingResult, error) {
 	if r.checkRoleForNamespace(role, pod.GetNamespace()) {
 		return &RoleMappingResult{
 			Role: role,
-			ExternalId: externalId,
+			ExternalID: externalID,
 			Namespace: pod.GetNamespace(),
 			IP: IP,
 		}, nil
@@ -89,16 +89,16 @@ func (r *RoleMapper) extractRoleARN(pod *v1.Pod) (string, error) {
 	return r.iam.RoleARN(rawRoleName), nil
 }
 
-// extractExternalId extracts the external id string if it's there, defaults to ""
-func (r *RoleMapper) extractExternalId(pod *v1.Pod) (string, error) {
-	rawExternalId, annotationPresent := pod.GetAnnotations()[r.externalId]
+// extractExternalID extracts the external id string if it's there, defaults to ""
+func (r *RoleMapper) extractExternalID(pod *v1.Pod) (string, error) {
+	rawExternalID, annotationPresent := pod.GetAnnotations()[r.externalID]
 
 	if !annotationPresent {
 		log.Debug("Defaulting external ID to empty string, will be ignored in sts.AssumeRole")
-		rawExternalId = ""
+		rawExternalID = ""
 	}
 
-	return string(rawExternalId), nil
+	return rawExternalID, nil
 }
 
 // checkRoleForNamespace checks the 'database' for a role allowed in a namespace,
@@ -171,11 +171,11 @@ func (r *RoleMapper) DumpDebugInfo() map[string]interface{} {
 }
 
 // NewRoleMapper returns a new RoleMapper for use.
-func NewRoleMapper(roleKey string, externalId string, defaultRole string, namespaceRestriction bool, namespaceKey string, iamInstance *iam.Client, kubeStore store, namespaceRestrictionFormat string) *RoleMapper {
+func NewRoleMapper(roleKey string, externalID string, defaultRole string, namespaceRestriction bool, namespaceKey string, iamInstance *iam.Client, kubeStore store, namespaceRestrictionFormat string) *RoleMapper {
 	return &RoleMapper{
 		defaultRoleARN:             iamInstance.RoleARN(defaultRole),
 		iamRoleKey:                 roleKey,
-		externalId:                 externalId,
+		externalID:                 externalID,
 		namespaceKey:               namespaceKey,
 		namespaceRestriction:       namespaceRestriction,
 		iam:                        iamInstance,

--- a/mappings/mapper_test.go
+++ b/mappings/mapper_test.go
@@ -89,6 +89,7 @@ func TestCheckRoleForNamespace(t *testing.T) {
 	var roleCheckTests = []struct {
 		test                       string
 		namespaceRestriction       bool
+		externalId                 string
 		defaultArn                 string
 		namespace                  string
 		namespaceAnnotations       map[string]string
@@ -99,6 +100,14 @@ func TestCheckRoleForNamespace(t *testing.T) {
 		{
 			test:                 "No restrictions",
 			namespaceRestriction: false,
+			roleARN:              "arn:aws:iam::123456789012:role/explicit-role",
+			namespace:            "default",
+			expectedResult:       true,
+		},
+		{
+			test:                 "No restrictions with external-id",
+			namespaceRestriction: false,
+			externalId:           "test-external-id-secret-is-not-secret",
 			roleARN:              "arn:aws:iam::123456789012:role/explicit-role",
 			namespace:            "default",
 			expectedResult:       true,
@@ -352,6 +361,7 @@ func TestCheckRoleForNamespace(t *testing.T) {
 		t.Run(tt.test, func(t *testing.T) {
 			rp := NewRoleMapper(
 				roleKey,
+				tt.externalId,
 				tt.defaultArn,
 				tt.namespaceRestriction,
 				namespaceKey,

--- a/mappings/mapper_test.go
+++ b/mappings/mapper_test.go
@@ -89,7 +89,7 @@ func TestCheckRoleForNamespace(t *testing.T) {
 	var roleCheckTests = []struct {
 		test                       string
 		namespaceRestriction       bool
-		externalId                 string
+		externalID                 string
 		defaultArn                 string
 		namespace                  string
 		namespaceAnnotations       map[string]string
@@ -107,7 +107,7 @@ func TestCheckRoleForNamespace(t *testing.T) {
 		{
 			test:                 "No restrictions with external-id",
 			namespaceRestriction: false,
-			externalId:           "test-external-id-secret-is-not-secret",
+			externalID:           "test-external-id-secret-is-not-secret",
 			roleARN:              "arn:aws:iam::123456789012:role/explicit-role",
 			namespace:            "default",
 			expectedResult:       true,
@@ -361,7 +361,7 @@ func TestCheckRoleForNamespace(t *testing.T) {
 		t.Run(tt.test, func(t *testing.T) {
 			rp := NewRoleMapper(
 				roleKey,
-				tt.externalId,
+				tt.externalID,
 				tt.defaultArn,
 				tt.namespaceRestriction,
 				namespaceKey,

--- a/mappings/mapper_test.go
+++ b/mappings/mapper_test.go
@@ -21,16 +21,15 @@ func TestExtractExternalID(t *testing.T) {
 		test               string
 		annotations        map[string]string
 		expectedExternalID string
-		expectError bool
 	}{
 		{
-			test:        "No external-id annotation",
-			annotations: map[string]string{},
+			test:               "No external-id annotation",
+			annotations:        map[string]string{},
 			expectedExternalID: "",
 		},
 		{
-			test:        "No default, has annotation",
-			annotations: map[string]string{externalIDKey: "secret-secrets-are-no-fun"},
+			test:               "No default, has annotation",
+			annotations:        map[string]string{externalIDKey: "secret-secrets-are-no-fun"},
 			expectedExternalID: "secret-secrets-are-no-fun",
 		},
 	}
@@ -43,15 +42,7 @@ func TestExtractExternalID(t *testing.T) {
 			pod := &v1.Pod{}
 			pod.Annotations = tt.annotations
 
-			resp, err := rp.extractExternalID(pod)
-			if tt.expectError && err == nil {
-				t.Error("Expected error however didn't recieve one")
-				return
-			}
-			if !tt.expectError && err != nil {
-				t.Errorf("Didn't expect error but recieved %s", err)
-				return
-			}
+			resp := rp.extractExternalID(pod)
 			if resp != tt.expectedExternalID {
 				t.Errorf("Response [%s] did not equal expected [%s]", resp, tt.expectedExternalID)
 				return

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,7 @@ const (
 	defaultAppPort                    = "8181"
 	defaultCacheSyncAttempts          = 10
 	defaultIAMRoleKey                 = "iam.amazonaws.com/role"
-	defaultExternalIdKey              = "iam.amazonaws.com/external-id"
+	defaultExternalIDKey              = "iam.amazonaws.com/external-id"
 	defaultLogLevel                   = "info"
 	defaultLogFormat                  = "text"
 	defaultMaxElapsedTime             = 2 * time.Second
@@ -53,7 +53,7 @@ type Server struct {
 	BaseRoleARN                string
 	DefaultIAMRole             string
 	IAMRoleKey                 string
-	ExternalIdKey              string
+	ExternalIDKey              string
 	IAMRoleSessionTTL          time.Duration
 	MetadataAddress            string
 	HostInterface              string
@@ -300,7 +300,7 @@ func (s *Server) roleHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 
 	roleLogger := logger.WithFields(log.Fields{
 		"pod.iam.role":        roleMapping.Role,
-		"pod.iam.external_id": roleMapping.ExternalId,
+		"pod.iam.external_id": roleMapping.ExternalID,
 		"ns.name":             roleMapping.Namespace,
 	})
 
@@ -314,7 +314,7 @@ func (s *Server) roleHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	credentials, err := s.iam.AssumeRole(wantedRoleARN, roleMapping.ExternalId, remoteIP, s.IAMRoleSessionTTL)
+	credentials, err := s.iam.AssumeRole(wantedRoleARN, roleMapping.ExternalID, remoteIP, s.IAMRoleSessionTTL)
 	if err != nil {
 		roleLogger.Errorf("Error assuming role %+v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -349,7 +349,7 @@ func (s *Server) Run(host, token, nodeName string, insecure bool) error {
 	s.k8s = k
 	s.iam = iam.NewClient(s.BaseRoleARN, s.UseRegionalStsEndpoint)
 	log.Debugln("Caches have been synced.  Proceeding with server.")
-	s.roleMapper = mappings.NewRoleMapper(s.IAMRoleKey, s.ExternalIdKey, s.DefaultIAMRole, s.NamespaceRestriction, s.NamespaceKey, s.iam, s.k8s, s.NamespaceRestrictionFormat)
+	s.roleMapper = mappings.NewRoleMapper(s.IAMRoleKey, s.ExternalIDKey, s.DefaultIAMRole, s.NamespaceRestriction, s.NamespaceKey, s.iam, s.k8s, s.NamespaceRestrictionFormat)
 	podSynched := s.k8s.WatchForPods(kube2iam.NewPodHandler(s.IAMRoleKey))
 	namespaceSynched := s.k8s.WatchForNamespaces(kube2iam.NewNamespaceHandler(s.NamespaceKey))
 
@@ -404,7 +404,7 @@ func NewServer() *Server {
 		MetricsPort:                defaultAppPort,
 		BackoffMaxElapsedTime:      defaultMaxElapsedTime,
 		IAMRoleKey:                 defaultIAMRoleKey,
-		ExternalIdKey:              defaultExternalIdKey,
+		ExternalIDKey:              defaultExternalIDKey,
 		BackoffMaxInterval:         defaultMaxInterval,
 		LogLevel:                   defaultLogLevel,
 		LogFormat:                  defaultLogFormat,


### PR DESCRIPTION
# Problem Statement
Currently IAM Roles created with an External ID cannot be proxied by kube2iam. Including an External ID is a [recommended design pattern when sharing IAM Roles across AWS accounts](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html#external-id-purpose). External IDs should be optionally configurable in pod metadata to support this type of IAM Role assumption.

# Summary
This change adds support for the `--external-id` parameter of `aws sts assume-role` [api calls](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html).

With this change clients can create pods with an external-id in addition to the role annotation. For example, the following IAM Role (`arn:aws:iam::123456789011:role/an-iam-role-with-an-external-id`)'s trust relationship document created in Account A (123456789011) allows Account B (123456789012) that hosts the cluster to assume a role that grants access to Account A resources:
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "AWS": "arn:aws:iam::123456789012:root"
      },
      "Action": "sts:AssumeRole",
      "Condition": {
        "StringEquals": {
          "sts:ExternalId": "external-id-preventing-confused-deputy-syndrome"
        }
      }
    }
  ]
}
```
Given that trust relationship document, pods can now be registered to a cluster in Account B with the following pod yaml:
```
apiVersion: v1
kind: Pod
metadata:
  name: a-pod-with-an-external-id
  labels:
    name: a-pod-with-an-external-id
  annotations:
    iam.amazonaws.com/role: arn:aws:iam::123456789011:role/an-iam-role-with-an-external-id
    iam.amazonaws.com/external-id: external-id-preventing-confused-deputy-syndrome
```