### PR TITLE
Update k8s client to attempt to resolve issue #178.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -216,7 +216,7 @@ imports:
   - pkg/util/runtime
   - pkg/util/wait
 - name: k8s.io/client-go
-  version: e121606b0d09b2e1c467183ee46217fa85a6b672
+  version: 249fa7a1d3aa05d8e423e8de91ffedd5a58243f5
   subpackages:
   - discovery
   - kubernetes

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/jtblin/kube2iam"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
@@ -97,13 +98,22 @@ func (k8s *Client) PodByIP(IP string) (*v1.Pod, error) {
 	}
 
 	if len(pods) == 1 {
-		return pods[0].(*v1.Pod), nil
+		p, ok := pods[0].(*v1.Pod)
+		if !ok {
+			return nil, fmt.Errorf("pods[0] is not *v1.Pod! %v", pods[0])
+		}
+		return p, nil
 	}
 
 	//This happens with `hostNetwork: true` pods
 	podNames := make([]string, len(pods))
 	for i, pod := range pods {
-		podNames[i] = pod.(*v1.Pod).ObjectMeta.Name
+		p, ok := pod.(*v1.Pod)
+		if !ok {
+			log.Errorf("pods[%d] is not *v1.Pod! %v", i, pod)
+		} else {
+			podNames[i] = p.ObjectMeta.Name
+		}
 	}
 	return nil, fmt.Errorf("%d pods (%v) with the ip %s indexed", len(pods), podNames, IP)
 }


### PR DESCRIPTION
Based on the suggestion of @rifelpet, I updated k8s.io/client-go to tag kubernetes-1.10.10. I've been running an image with this for a few hours, and it seems not to exhibit the issue anymore. 