### PR TITLE
Add kustomize config

### DIFF
--- a/kustomize/daemonset.yaml
+++ b/kustomize/daemonset.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: kube2iam
+  name: kube2iam
+  namespace: kube-system
+spec:
+  selector:
+   matchLabels:
+    app.kubernetes.io/name: kube2iam
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube2iam
+    spec:
+      containers:
+      - name: kube2iam
+        image: jtblin/kube2iam:latest
+        args:
+        - --host-ip=$(HOST_IP)
+        - --iptables=true
+        - --node=$(NODE_NAME)
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - containerPort: 8181
+          protocol: TCP
+        securityContext:
+          privileged: true
+      hostNetwork: true
+      serviceAccountName: kube2iam

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -1,8 +1,3 @@
-commonLabels:
-  app.kubernetes.io/name: kube2iam
-
-namespace: kube-system
-
 resources:
 - daemonset.yaml
 - rbac.yaml

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -1,0 +1,8 @@
+commonLabels:
+  app.kubernetes.io/name: kube2iam
+
+namespace: kube-system
+
+resources:
+- daemonset.yaml
+- rbac.yaml

--- a/kustomize/rbac.yaml
+++ b/kustomize/rbac.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube2iam
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube2iam
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube2iam
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube2iam
+subjects:
+- kind: ServiceAccount
+  name: kube2iam
+  namespace: kube-system
+...

--- a/kustomize/rbac.yaml
+++ b/kustomize/rbac.yaml
@@ -2,12 +2,16 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/name: kube2iam
   name: kube2iam
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/name: kube2iam
   name: kube2iam
 rules:
 - apiGroups:
@@ -23,6 +27,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/name: kube2iam
   name: kube2iam
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This adds a set of manifests for use as a [kustomize](https://github.com/kubernetes-sigs/kustomize) base layer. There might also an argument to be made for simplifying the README and pointing people to these instead.