### PR TITLE
Fix the log.Debug issue in go test

### DIFF
--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -86,7 +86,7 @@ func (r *RoleMapper) checkRoleForNamespace(roleArn string, namespace string) boo
 
 	ns, err := r.store.NamespaceByName(namespace)
 	if err != nil {
-		log.Debug("Unable to find an indexed namespace of %s", namespace)
+		log.Debugf("Unable to find an indexed namespace of %s", namespace)
 		return false
 	}
 


### PR DESCRIPTION
Signed-off-by: Li Yi <denverdino@gmail.com>

The log.Debug is incorrect in the mappings/mapper.go

```
$ go version
go version go1.11.1 darwin/amd64
$ go test ./...
...
# github.com/jtblin/kube2iam/mappings
mappings/mapper.go:89: Debug call has possible formatting directive %s
...
FAIL	github.com/jtblin/kube2iam/mappings [build failed]
...
```

The 		

```
log.Debug("Unable to find an indexed namespace of %s", namespace)
```

should be

```
log.Debugf("Unable to find an indexed namespace of %s", namespace)
```