### PR TITLE
don't add trailing slash to provided --base-role-arn

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,9 +71,6 @@ func main() {
 		if !iam.IsValidBaseARN(s.BaseRoleARN) {
 			log.Fatalf("Invalid --base-role-arn specified, expected: %s", iam.ARNRegexp.String())
 		}
-		if !strings.HasSuffix(s.BaseRoleARN, "/") {
-			s.BaseRoleARN += "/"
-		}
 	}
 
 	if s.AutoDiscoverBaseArn {


### PR DESCRIPTION
The current implementation always adds a trailing slash to the baseRoleArn if the last character ist not already a slash. This behavior breaks my use-case.

Here's an example of my use case:
full arn:
 - A) arn:aws:iam::1234567890:role/helloworld-foo
 - B) arn:aws:iam::1234567890:role/helloworld-bar

base-role-arn: ```arn:aws:iam::1234567890:role/helloworld-```

pod annotation for iam A: ```iam.amazonaws.com/role: foo```
pod annotation for iam B: ```iam.amazonaws.com/role: foo```


Everything else in the repository would already allow my use-case to work, but the fact that the slash is currently always enforced breaks it completely.

As a sidenote the current regex for validating is ```^arn:(\w|-)*:iam::\d+:role\/?(\w+|-|\/|\.)*$```
But according to the [AWS IAM reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-names) slashes are not allowed as a part of the role-name
```
Names of users, groups, roles, policies, instance profiles, and server certificates must be alphanumeric, including the following common characters: plus (+), equal (=), comma (,), period (.), at (@), underscore (_), and hyphen (-).
```

Therefore I think the correct regex should also be:  ```^arn:(\w|-)*:iam::\d+:role\/?(\w+|\+|@|-|\.|\,|\=|\_)*$```
Although I did not touch that as I have not verified if the AWS documentation is correct in that regard.
