### PR TITLE
implementing iptables retry

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,7 +108,7 @@ func main() {
 	}
 
 	if s.AddIPTablesRule {
-		if s.IPTablesBackoffMaxElapsedTime != "" {
+		if s.IPTablesBackoffMaxElapsedTime != nil {
 			iptablesOperation := func() error {
 				return iptables.AddRule(s.AppPort, s.MetadataAddress, s.HostInterface, s.HostIP)
 			}
@@ -117,7 +117,7 @@ func main() {
 			iptablesBackoff.MaxElapsedTime = s.IPTablesBackoffMaxElapsedTime * time.Second
 
 			iptablesBackoff := backoff.NewExponentialBackOff()
-			err := backoff.Retry(iptablesOperation, iptablesBackoff)
+			err = backoff.Retry(iptablesOperation, iptablesBackoff)
 			if err != nil {
 				log.Fatalf("%s", err)
 			}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
+	"github.com/cenk/backoff"
 	"github.com/jtblin/kube2iam/iam"
 	"github.com/jtblin/kube2iam/iptables"
 	"github.com/jtblin/kube2iam/server"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,23 +108,16 @@ func main() {
 	}
 
 	if s.AddIPTablesRule {
-		if s.IPTablesBackoffMaxElapsedTime != nil {
-			iptablesOperation := func() error {
-				return iptables.AddRule(s.AppPort, s.MetadataAddress, s.HostInterface, s.HostIP)
-			}
+		iptablesOperation := func() error {
+			return iptables.AddRule(s.AppPort, s.MetadataAddress, s.HostInterface, s.HostIP)
+		}
 
-			iptablesBackoff := backoff.NewExponentialBackOff()
-			iptablesBackoff.MaxElapsedTime = s.IPTablesBackoffMaxElapsedTime * time.Second
+		iptablesBackoff := backoff.NewExponentialBackOff()
+		iptablesBackoff.MaxElapsedTime = s.IPTablesBackoffMaxElapsedTime
 
-			iptablesBackoff := backoff.NewExponentialBackOff()
-			err = backoff.Retry(iptablesOperation, iptablesBackoff)
-			if err != nil {
-				log.Fatalf("%s", err)
-			}
-		} else {
-			if err := iptables.AddRule(s.AppPort, s.MetadataAddress, s.HostInterface, s.HostIP); err != nil {
-				log.Fatalf("%s", err)
-			}
+		err = backoff.Retry(iptablesOperation, iptablesBackoff)
+		if err != nil {
+			log.Fatalf("%s", err)
 		}
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,8 +108,8 @@ func main() {
 	}
 
 	if s.AddIPTablesRule {
-		if s.IPTablesBackoffMaxElapsedTime {
-			operation := func() error {
+		if s.IPTablesBackoffMaxElapsedTime != "" {
+			iptablesOperation := func() error {
 				return iptables.AddRule(s.AppPort, s.MetadataAddress, s.HostInterface, s.HostIP)
 			}
 
@@ -117,7 +117,7 @@ func main() {
 			iptablesBackoff.MaxElapsedTime = s.IPTablesBackoffMaxElapsedTime * time.Second
 
 			iptablesBackoff := backoff.NewExponentialBackOff()
-			err := backoff.Retry(operation, iptablesBackoff)
+			err := backoff.Retry(iptablesOperation, iptablesBackoff)
 			if err != nil {
 				log.Fatalf("%s", err)
 			}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"

--- a/server/server.go
+++ b/server/server.go
@@ -31,6 +31,7 @@ const (
 	defaultLogLevel                   = "info"
 	defaultLogFormat                  = "text"
 	defaultMaxElapsedTime             = 2 * time.Second
+	defaultIPTablesMaxElapsedTime     = 1 * time.Second
 	defaultIAMRoleSessionTTL          = 15 * time.Minute
 	defaultMaxInterval                = 1 * time.Second
 	defaultMetadataAddress            = "169.254.169.254"
@@ -398,17 +399,18 @@ func (s *Server) Run(host, token, nodeName string, insecure bool) error {
 // NewServer will create a new Server with default values.
 func NewServer() *Server {
 	return &Server{
-		AppPort:                    defaultAppPort,
-		MetricsPort:                defaultAppPort,
-		BackoffMaxElapsedTime:      defaultMaxElapsedTime,
-		IAMRoleKey:                 defaultIAMRoleKey,
-		BackoffMaxInterval:         defaultMaxInterval,
-		LogLevel:                   defaultLogLevel,
-		LogFormat:                  defaultLogFormat,
-		MetadataAddress:            defaultMetadataAddress,
-		NamespaceKey:               defaultNamespaceKey,
-		NamespaceRestrictionFormat: defaultNamespaceRestrictionFormat,
-		HealthcheckFailReason:      "Healthcheck not yet performed",
-		IAMRoleSessionTTL:          defaultIAMRoleSessionTTL,
+		AppPort:                       defaultAppPort,
+		MetricsPort:                   defaultAppPort,
+		BackoffMaxElapsedTime:         defaultMaxElapsedTime,
+		IPTablesBackoffMaxElapsedTime: defaultIPTablesMaxElapsedTime,
+		IAMRoleKey:                    defaultIAMRoleKey,
+		BackoffMaxInterval:            defaultMaxInterval,
+		LogLevel:                      defaultLogLevel,
+		LogFormat:                     defaultLogFormat,
+		MetadataAddress:               defaultMetadataAddress,
+		NamespaceKey:                  defaultNamespaceKey,
+		NamespaceRestrictionFormat:    defaultNamespaceRestrictionFormat,
+		HealthcheckFailReason:         "Healthcheck not yet performed",
+		IAMRoleSessionTTL:             defaultIAMRoleSessionTTL,
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -45,39 +45,40 @@ var registeredHandlerNames []string
 // Server encapsulates all of the parameters necessary for starting up
 // the server. These can either be set via command line or directly.
 type Server struct {
-	APIServer                  string
-	APIToken                   string
-	AppPort                    string
-	MetricsPort                string
-	BaseRoleARN                string
-	DefaultIAMRole             string
-	IAMRoleKey                 string
-	IAMRoleSessionTTL          time.Duration
-	MetadataAddress            string
-	HostInterface              string
-	HostIP                     string
-	NodeName                   string
-	NamespaceKey               string
-	LogLevel                   string
-	LogFormat                  string
-	NamespaceRestrictionFormat string
-	UseRegionalStsEndpoint     bool
-	AddIPTablesRule            bool
-	AutoDiscoverBaseArn        bool
-	AutoDiscoverDefaultRole    bool
-	Debug                      bool
-	Insecure                   bool
-	NamespaceRestriction       bool
-	Verbose                    bool
-	Version                    bool
-	iam                        *iam.Client
-	k8s                        *k8s.Client
-	roleMapper                 *mappings.RoleMapper
-	BackoffMaxElapsedTime      time.Duration
-	BackoffMaxInterval         time.Duration
-	InstanceID                 string
-	HealthcheckFailReason      string
-	healthcheckTicker          *time.Ticker
+	APIServer                     string
+	APIToken                      string
+	AppPort                       string
+	MetricsPort                   string
+	BaseRoleARN                   string
+	DefaultIAMRole                string
+	IAMRoleKey                    string
+	IAMRoleSessionTTL             time.Duration
+	MetadataAddress               string
+	HostInterface                 string
+	HostIP                        string
+	NodeName                      string
+	NamespaceKey                  string
+	LogLevel                      string
+	LogFormat                     string
+	NamespaceRestrictionFormat    string
+	UseRegionalStsEndpoint        bool
+	AddIPTablesRule               bool
+	AutoDiscoverBaseArn           bool
+	AutoDiscoverDefaultRole       bool
+	Debug                         bool
+	Insecure                      bool
+	NamespaceRestriction          bool
+	Verbose                       bool
+	Version                       bool
+	iam                           *iam.Client
+	k8s                           *k8s.Client
+	roleMapper                    *mappings.RoleMapper
+	BackoffMaxElapsedTime         time.Duration
+	BackoffMaxInterval            time.Duration
+	IPTablesBackoffMaxElapsedTime time.Duration
+	InstanceID                    string
+	HealthcheckFailReason         string
+	healthcheckTicker             *time.Ticker
 }
 
 type appHandlerFunc func(*log.Entry, http.ResponseWriter, *http.Request)


### PR DESCRIPTION
I've been running into an issue where, when running as a daemonset, kube2iam will fail to insert its iptables rule and immediately fatals with: "iptables: Resource temporarily unavailable."

This is likely due to many processes attempting to update the iptables ruleset at the same time. Ideally there would be a retry backoff implemented to the rule adding in kube2iam as a workaround to this race condition.