### PR TITLE
Do not check the pod's deletionTimestamp when determining if a pod is active

### DIFF
--- a/pod.go
+++ b/pod.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -72,14 +71,9 @@ func (p *PodHandler) OnDelete(obj interface{}) {
 }
 
 func isPodActive(p *v1.Pod) bool {
-	podDeleted := false
-	if p.DeletionTimestamp != nil {
-		podDeleted = p.DeletionTimestamp.Before(unversioned.Now())
-	}
 	return p.Status.PodIP != "" &&
 		v1.PodSucceeded != p.Status.Phase &&
-		v1.PodFailed != p.Status.Phase &&
-		!podDeleted
+		v1.PodFailed != p.Status.Phase
 }
 
 // PodIPIndexFunc maps a given Pod to it's IP for caching.


### PR DESCRIPTION
Fixing a regression originating from #173, this was causing nil entries in the pod index which resulted in credentials failing to be issued.

See #178 for more information.