### PR TITLE
Allow underscore in IAM role name

### DIFF
--- a/iam/arn.go
+++ b/iam/arn.go
@@ -13,7 +13,7 @@ const fullArnPrefix = "arn:"
 
 // ARNRegexp is the regex to check that the base ARN is valid,
 // see http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns.
-var ARNRegexp = regexp.MustCompile(`^arn:(\w|-)*:iam::\d+:role\/?(\w+|-|\/|\.)*$`)
+var ARNRegexp = regexp.MustCompile(`^arn:(\w|-)*:iam::\d+:role\/?(\w+|-|_|\/|\.)*$`)
 
 // IsValidBaseARN validates that the base ARN is valid.
 func IsValidBaseARN(arn string) bool {


### PR DESCRIPTION
# Issue
ARN of IAM role to assume where role name or path has an underscore is not compiling regex.

# Expected behaviour
ARN compiles regex.

# Fix
Add underscore in regex match.