### PR TITLE
Add support for externalId as an optional annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ spec:
 ### kubernetes annotation
 
 Add an `iam.amazonaws.com/role` annotation to your pods with the role that you want to assume for this pod.
+The optional `iam.amazonaws.com/external-id` will allow the use of an ExternalId as part of the assume role
 
 ```yaml
 apiVersion: v1
@@ -207,6 +208,7 @@ metadata:
     name: aws-cli
   annotations:
     iam.amazonaws.com/role: role-arn
+    iam.amazonaws.com/external-id: external-id
 spec:
   containers:
   - image: fstab/aws-cli
@@ -561,6 +563,7 @@ Usage of kube2iam:
       --host-interface string                 Host interface for proxying AWS metadata (default "docker0")
       --host-ip string                        IP address of host
       --iam-role-key string                   Pod annotation key used to retrieve the IAM role (default "iam.amazonaws.com/role")
+      --iam-external-id string                Pod annotation key used to retrieve the IAM ExternalId (default "iam.amazonaws.com/external-id")
       --insecure                              Kubernetes server should be accessed without verifying the TLS. Testing only
       --iptables                              Add iptables rule (also requires --host-ip)
       --log-format string                     Log format (text/json) (default "text")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,7 +22,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.Debug, "debug", s.Debug, "Enable debug features")
 	fs.StringVar(&s.DefaultIAMRole, "default-role", s.DefaultIAMRole, "Fallback role to use when annotation is not set")
 	fs.StringVar(&s.IAMRoleKey, "iam-role-key", s.IAMRoleKey, "Pod annotation key used to retrieve the IAM role")
-	fs.StringVar(&s.IAMExternalId, "iam-external-id", s.IAMExternalId, "Pod annotation key used to retrieve the IAM ExternalId")
+	fs.StringVar(&s.IAMExternalID, "iam-external-id", s.IAMExternalID, "Pod annotation key used to retrieve the IAM ExternalId")
 	fs.DurationVar(&s.IAMRoleSessionTTL, "iam-role-session-ttl", s.IAMRoleSessionTTL, "TTL for the assume role session")
 	fs.BoolVar(&s.Insecure, "insecure", false, "Kubernetes server should be accessed without verifying the TLS. Testing only")
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the ec2 metadata")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.Debug, "debug", s.Debug, "Enable debug features")
 	fs.StringVar(&s.DefaultIAMRole, "default-role", s.DefaultIAMRole, "Fallback role to use when annotation is not set")
 	fs.StringVar(&s.IAMRoleKey, "iam-role-key", s.IAMRoleKey, "Pod annotation key used to retrieve the IAM role")
+	fs.StringVar(&s.IAMExternalId, "iam-external-id", s.IAMExternalId, "Pod annotation key used to retrieve the IAM ExternalId")
 	fs.DurationVar(&s.IAMRoleSessionTTL, "iam-role-session-ttl", s.IAMRoleSessionTTL, "TTL for the assume role session")
 	fs.BoolVar(&s.Insecure, "insecure", false, "Kubernetes server should be accessed without verifying the TLS. Testing only")
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the ec2 metadata")

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -156,7 +156,7 @@ func (iam *Client) AssumeRole(roleARN, externalID string, remoteIP string, sessi
 		}
 		// Only inject the externalID if one was provided with the request
 		if (externalID != "") {
-			assumeRoleInput.SetExternalID(externalID)
+			assumeRoleInput.SetExternalId(externalID)
 		}
 		resp, err := svc.AssumeRole(&assumeRoleInput)
 		if err != nil {

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -126,7 +126,7 @@ func (iam *Client) EndpointFor(service, region string, optFns ...func(*endpoints
 }
 
 // AssumeRole returns an IAM role Credentials using AWS STS.
-func (iam *Client) AssumeRole(roleARN, remoteIP string, sessionTTL time.Duration) (*Credentials, error) {
+func (iam *Client) AssumeRole(roleARN, remoteIP string, sessionTTL time.Duration, externalId string) (*Credentials, error) {
 	hitCache := true
 	item, err := cache.Fetch(roleARN, sessionTTL, func() (interface{}, error) {
 		hitCache = false
@@ -149,11 +149,16 @@ func (iam *Client) AssumeRole(roleARN, remoteIP string, sessionTTL time.Duration
 			config = config.WithEndpointResolver(iam)
 		}
 		svc := sts.New(sess, config)
-		resp, err := svc.AssumeRole(&sts.AssumeRoleInput{
+		assumeRoleInput := sts.AssumeRoleInput{
 			DurationSeconds: aws.Int64(int64(sessionTTL.Seconds() * 2)),
 			RoleArn:         aws.String(roleARN),
 			RoleSessionName: aws.String(sessionName(roleARN, remoteIP)),
-		})
+		}
+		// Only inject the externalId if one was provided with the request
+		if (externalId != "") {
+			assumeRoleInput.SetExternalId(externalId)
+		}
+		resp, err := svc.AssumeRole(&assumeRoleInput)
 		if err != nil {
 			return nil, err
 		}

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -126,7 +126,7 @@ func (iam *Client) EndpointFor(service, region string, optFns ...func(*endpoints
 }
 
 // AssumeRole returns an IAM role Credentials using AWS STS.
-func (iam *Client) AssumeRole(roleARN, remoteIP string, sessionTTL time.Duration, externalId string) (*Credentials, error) {
+func (iam *Client) AssumeRole(roleARN, externalId string, remoteIP string, sessionTTL time.Duration) (*Credentials, error) {
 	hitCache := true
 	item, err := cache.Fetch(roleARN, sessionTTL, func() (interface{}, error) {
 		hitCache = false

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -126,7 +126,7 @@ func (iam *Client) EndpointFor(service, region string, optFns ...func(*endpoints
 }
 
 // AssumeRole returns an IAM role Credentials using AWS STS.
-func (iam *Client) AssumeRole(roleARN, externalId string, remoteIP string, sessionTTL time.Duration) (*Credentials, error) {
+func (iam *Client) AssumeRole(roleARN, externalID string, remoteIP string, sessionTTL time.Duration) (*Credentials, error) {
 	hitCache := true
 	item, err := cache.Fetch(roleARN, sessionTTL, func() (interface{}, error) {
 		hitCache = false
@@ -154,9 +154,9 @@ func (iam *Client) AssumeRole(roleARN, externalId string, remoteIP string, sessi
 			RoleArn:         aws.String(roleARN),
 			RoleSessionName: aws.String(sessionName(roleARN, remoteIP)),
 		}
-		// Only inject the externalId if one was provided with the request
-		if (externalId != "") {
-			assumeRoleInput.SetExternalId(externalId)
+		// Only inject the externalID if one was provided with the request
+		if (externalID != "") {
+			assumeRoleInput.SetExternalID(externalID)
 		}
 		resp, err := svc.AssumeRole(&assumeRoleInput)
 		if err != nil {

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -65,7 +65,7 @@ func (r *RoleMapper) GetExternalIdMapping(IP string) (string, error) {
 	pod, err := r.store.PodByIP(IP)
 	// If attempting to get a Pod that maps to multiple IPs
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	externalId, _ := pod.GetAnnotations()[r.iamExternalIdKey]

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -17,7 +17,7 @@ import (
 type RoleMapper struct {
 	defaultRoleARN             string
 	iamRoleKey                 string
-	iamExternalIdKey           string
+	iamExternalIDKey           string
 	namespaceKey               string
 	namespaceRestriction       bool
 	iam                        *iam.Client
@@ -60,17 +60,17 @@ func (r *RoleMapper) GetRoleMapping(IP string) (*RoleMappingResult, error) {
 	return nil, fmt.Errorf("role requested %s not valid for namespace of pod at %s with namespace %s", role, IP, pod.GetNamespace())
 }
 
-// GetExternalIdMapping returns the externalId based on IP address
-func (r *RoleMapper) GetExternalIdMapping(IP string) (string, error) {
+// GetExternalIDMapping returns the externalID based on IP address
+func (r *RoleMapper) GetExternalIDMapping(IP string) (string, error) {
 	pod, err := r.store.PodByIP(IP)
 	// If attempting to get a Pod that maps to multiple IPs
 	if err != nil {
 		return "", err
 	}
 
-	externalId, _ := pod.GetAnnotations()[r.iamExternalIdKey]
+	externalID := pod.GetAnnotations()[r.iamExternalIDKey]
 
-	return externalId, nil
+	return externalID, nil
 }
 
 // extractQualifiedRoleName extracts a fully qualified ARN for a given pod,
@@ -161,11 +161,11 @@ func (r *RoleMapper) DumpDebugInfo() map[string]interface{} {
 }
 
 // NewRoleMapper returns a new RoleMapper for use.
-func NewRoleMapper(roleKey string, externalIdKey string, defaultRole string, namespaceRestriction bool, namespaceKey string, iamInstance *iam.Client, kubeStore store, namespaceRestrictionFormat string) *RoleMapper {
+func NewRoleMapper(roleKey string, externalIDKey string, defaultRole string, namespaceRestriction bool, namespaceKey string, iamInstance *iam.Client, kubeStore store, namespaceRestrictionFormat string) *RoleMapper {
 	return &RoleMapper{
 		defaultRoleARN:       iamInstance.RoleARN(defaultRole),
 		iamRoleKey:           roleKey,
-		iamExternalIdKey:     externalIdKey,
+		iamExternalIDKey:     externalIDKey,
 		namespaceKey:         namespaceKey,
 		namespaceRestriction: namespaceRestriction,
 		iam:                  iamInstance,

--- a/mappings/mapper_test.go
+++ b/mappings/mapper_test.go
@@ -12,6 +12,7 @@ import (
 const (
 	defaultBaseRole = "arn:aws:iam::123456789012:role/"
 	roleKey         = "roleKey"
+	externalIdKey   = "externalIdKey"
 	namespaceKey    = "namespaceKey"
 )
 
@@ -57,11 +58,18 @@ func TestExtractRoleARN(t *testing.T) {
 			defaultRole: "explicit-default-role",
 			expectedARN: "arn:aws:iam::123456789012:role/explicit-default-role",
 		},
+		{
+			test:        "Default present, has annotations, has externalId",
+			annotations: map[string]string{roleKey: "something", externalIdKey: "externalId"},
+			defaultRole: "explicit-default-role",
+			expectedARN: "arn:aws:iam::123456789012:role/something",
+		},
 	}
 	for _, tt := range roleExtractionTests {
 		t.Run(tt.test, func(t *testing.T) {
 			rp := RoleMapper{}
 			rp.iamRoleKey = "roleKey"
+			rp.iamExternalIdKey = "externalIdKey"
 			rp.defaultRoleARN = tt.defaultRole
 			rp.iam = &iam.Client{BaseARN: defaultBaseRole}
 
@@ -93,6 +101,7 @@ func TestCheckRoleForNamespace(t *testing.T) {
 		namespace                  string
 		namespaceAnnotations       map[string]string
 		roleARN                    string
+		externalId                 string
 		namespaceRestrictionFormat string
 		expectedResult             bool
 	}{
@@ -352,6 +361,7 @@ func TestCheckRoleForNamespace(t *testing.T) {
 		t.Run(tt.test, func(t *testing.T) {
 			rp := NewRoleMapper(
 				roleKey,
+				externalIdKey,
 				tt.defaultArn,
 				tt.namespaceRestriction,
 				namespaceKey,

--- a/mappings/mapper_test.go
+++ b/mappings/mapper_test.go
@@ -12,7 +12,7 @@ import (
 const (
 	defaultBaseRole = "arn:aws:iam::123456789012:role/"
 	roleKey         = "roleKey"
-	externalIdKey   = "externalIdKey"
+	externalIDKey   = "externalIDKey"
 	namespaceKey    = "namespaceKey"
 )
 
@@ -59,8 +59,8 @@ func TestExtractRoleARN(t *testing.T) {
 			expectedARN: "arn:aws:iam::123456789012:role/explicit-default-role",
 		},
 		{
-			test:        "Default present, has annotations, has externalId",
-			annotations: map[string]string{roleKey: "something", externalIdKey: "externalId"},
+			test:        "Default present, has annotations, has externalID",
+			annotations: map[string]string{roleKey: "something", externalIDKey: "externalID"},
 			defaultRole: "explicit-default-role",
 			expectedARN: "arn:aws:iam::123456789012:role/something",
 		},
@@ -69,7 +69,7 @@ func TestExtractRoleARN(t *testing.T) {
 		t.Run(tt.test, func(t *testing.T) {
 			rp := RoleMapper{}
 			rp.iamRoleKey = "roleKey"
-			rp.iamExternalIdKey = "externalIdKey"
+			rp.iamExternalIDKey = "externalIDKey"
 			rp.defaultRoleARN = tt.defaultRole
 			rp.iam = &iam.Client{BaseARN: defaultBaseRole}
 
@@ -101,7 +101,7 @@ func TestCheckRoleForNamespace(t *testing.T) {
 		namespace                  string
 		namespaceAnnotations       map[string]string
 		roleARN                    string
-		externalId                 string
+		externalID                 string
 		namespaceRestrictionFormat string
 		expectedResult             bool
 	}{
@@ -361,7 +361,7 @@ func TestCheckRoleForNamespace(t *testing.T) {
 		t.Run(tt.test, func(t *testing.T) {
 			rp := NewRoleMapper(
 				roleKey,
-				externalIdKey,
+				externalIDKey,
 				tt.defaultArn,
 				tt.namespaceRestriction,
 				namespaceKey,

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,7 @@ const (
 	defaultAppPort                    = "8181"
 	defaultCacheSyncAttempts          = 10
 	defaultIAMRoleKey                 = "iam.amazonaws.com/role"
-	defaultIAMExternalId              = "iam.amazonaws.com/external-id"
+	defaultIAMExternalID              = "iam.amazonaws.com/external-id"
 	defaultLogLevel                   = "info"
 	defaultLogFormat                  = "text"
 	defaultMaxElapsedTime             = 2 * time.Second
@@ -53,7 +53,7 @@ type Server struct {
 	BaseRoleARN                string
 	DefaultIAMRole             string
 	IAMRoleKey                 string
-	IAMExternalId              string
+	IAMExternalID              string
 	IAMRoleSessionTTL          time.Duration
 	MetadataAddress            string
 	HostInterface              string
@@ -374,7 +374,7 @@ func (s *Server) Run(host, token, nodeName string, insecure bool) error {
 	s.k8s = k
 	s.iam = iam.NewClient(s.BaseRoleARN, s.UseRegionalStsEndpoint)
 	log.Debugln("Caches have been synced.  Proceeding with server.")
-	s.roleMapper = mappings.NewRoleMapper(s.IAMRoleKey, s.IAMExternalId, s.DefaultIAMRole, s.NamespaceRestriction, s.NamespaceKey, s.iam, s.k8s, s.NamespaceRestrictionFormat)
+	s.roleMapper = mappings.NewRoleMapper(s.IAMRoleKey, s.IAMExternalID, s.DefaultIAMRole, s.NamespaceRestriction, s.NamespaceKey, s.iam, s.k8s, s.NamespaceRestrictionFormat)
 	podSynched := s.k8s.WatchForPods(kube2iam.NewPodHandler(s.IAMRoleKey))
 	namespaceSynched := s.k8s.WatchForNamespaces(kube2iam.NewNamespaceHandler(s.NamespaceKey))
 
@@ -429,7 +429,7 @@ func NewServer() *Server {
 		MetricsPort:                defaultAppPort,
 		BackoffMaxElapsedTime:      defaultMaxElapsedTime,
 		IAMRoleKey:                 defaultIAMRoleKey,
-		IAMExternalId:              defaultIAMExternalId,
+		IAMExternalID:              defaultIAMExternalID,
 		BackoffMaxInterval:         defaultMaxInterval,
 		LogLevel:                   defaultLogLevel,
 		LogFormat:                  defaultLogFormat,

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ const (
 	defaultAppPort                    = "8181"
 	defaultCacheSyncAttempts          = 10
 	defaultIAMRoleKey                 = "iam.amazonaws.com/role"
+	defaultIAMExternalId              = "iam.amazonaws.com/external-id"
 	defaultLogLevel                   = "info"
 	defaultLogFormat                  = "text"
 	defaultMaxElapsedTime             = 2 * time.Second
@@ -52,6 +53,7 @@ type Server struct {
 	BaseRoleARN                string
 	DefaultIAMRole             string
 	IAMRoleKey                 string
+	IAMExternalId              string
 	IAMRoleSessionTTL          time.Duration
 	MetadataAddress            string
 	HostInterface              string
@@ -311,7 +313,9 @@ func (s *Server) roleHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	credentials, err := s.iam.AssumeRole(wantedRoleARN, remoteIP, s.IAMRoleSessionTTL)
+	externalId := mux.Vars(r)["externalId"]
+
+	credentials, err := s.iam.AssumeRole(wantedRoleARN, remoteIP, s.IAMRoleSessionTTL, externalId)
 	if err != nil {
 		roleLogger.Errorf("Error assuming role %+v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -346,7 +350,7 @@ func (s *Server) Run(host, token, nodeName string, insecure bool) error {
 	s.k8s = k
 	s.iam = iam.NewClient(s.BaseRoleARN, s.UseRegionalStsEndpoint)
 	log.Debugln("Caches have been synced.  Proceeding with server.")
-	s.roleMapper = mappings.NewRoleMapper(s.IAMRoleKey, s.DefaultIAMRole, s.NamespaceRestriction, s.NamespaceKey, s.iam, s.k8s, s.NamespaceRestrictionFormat)
+	s.roleMapper = mappings.NewRoleMapper(s.IAMRoleKey, s.IAMExternalId, s.DefaultIAMRole, s.NamespaceRestriction, s.NamespaceKey, s.iam, s.k8s, s.NamespaceRestrictionFormat)
 	podSynched := s.k8s.WatchForPods(kube2iam.NewPodHandler(s.IAMRoleKey))
 	namespaceSynched := s.k8s.WatchForNamespaces(kube2iam.NewNamespaceHandler(s.NamespaceKey))
 
@@ -375,7 +379,7 @@ func (s *Server) Run(host, token, nodeName string, insecure bool) error {
 	r.Handle("/{version}/meta-data/iam/security-credentials/", securityHandler)
 	r.Handle(
 		"/{version}/meta-data/iam/security-credentials/{role:.*}",
-		newAppHandler("roleHandler", s.roleHandler))
+		newAppHandler("roleHandler", s.roleHandler)).Queries("externalId", "{externalId}")
 	r.Handle("/healthz", newAppHandler("healthHandler", s.healthHandler))
 
 	if s.MetricsPort == s.AppPort {
@@ -401,6 +405,7 @@ func NewServer() *Server {
 		MetricsPort:                defaultAppPort,
 		BackoffMaxElapsedTime:      defaultMaxElapsedTime,
 		IAMRoleKey:                 defaultIAMRoleKey,
+		IAMExternalId:              defaultIAMExternalId,
 		BackoffMaxInterval:         defaultMaxInterval,
 		LogLevel:                   defaultLogLevel,
 		LogFormat:                  defaultLogFormat,

--- a/server/server.go
+++ b/server/server.go
@@ -184,11 +184,11 @@ func (s *Server) getRoleMapping(IP string) (*mappings.RoleMappingResult, error) 
 	return roleMapping, nil
 }
 
-func (s *Server) getExternalIdMapping(IP string) (string, error) {
-	var externalId string
+func (s *Server) getExternalIDMapping(IP string) (string, error) {
+	var externalID string
 	var err error
 	operation := func() error {
-		externalId, err = s.roleMapper.GetExternalIdMapping(IP)
+		externalID, err = s.roleMapper.GetExternalIDMapping(IP)
 		return err
 	}
 
@@ -201,7 +201,7 @@ func (s *Server) getExternalIdMapping(IP string) (string, error) {
 		return "", err
 	}
 
-	return externalId, nil
+	return externalID, nil
 }
 
 func (s *Server) beginPollHealthcheck(interval time.Duration) {
@@ -318,7 +318,7 @@ func (s *Server) roleHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	externalId, err := s.getExternalIdMapping(remoteIP)
+	externalID, err := s.getExternalIDMapping(remoteIP)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -339,7 +339,7 @@ func (s *Server) roleHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	credentials, err := s.iam.AssumeRole(wantedRoleARN, externalId, remoteIP, s.IAMRoleSessionTTL)
+	credentials, err := s.iam.AssumeRole(wantedRoleARN, externalID, remoteIP, s.IAMRoleSessionTTL)
 	if err != nil {
 		roleLogger.Errorf("Error assuming role %+v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
AWS supports a filtering system via `ExternalId` which allows to verify that the system attempting to assume the role is not making a mistake.
This adds the support of an externalId annotation (defaults to `iam.amazonaws.com/external-id`) so when the prod is created, an externalId can be provided and passed through as part of the `assume-role` operation.