### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ spec:
 Example for a `CronJob`:
 
 ```yaml
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: my-cronjob


### PR DESCRIPTION
updated example to use working API, otherwise kubectl returns `no matches for kind "CronJob" in version "batch/v1"`