### PR TITLE
mount /run/xtables.lock from host

### DIFF
--- a/examples/eks-example.yml
+++ b/examples/eks-example.yml
@@ -74,3 +74,12 @@ spec:
               name: http
           securityContext:
             privileged: true
+          volumeMounts:
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+      volumes:
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate

--- a/kustomize/base/daemonset.yaml
+++ b/kustomize/base/daemonset.yaml
@@ -36,5 +36,14 @@ spec:
           protocol: TCP
         securityContext:
           privileged: true
+        volumeMounts:
+          - mountPath: /run/xtables.lock
+            name: xtables-lock
+            readOnly: false
       hostNetwork: true
       serviceAccountName: kube2iam
+      volumes:
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate


### PR DESCRIPTION
Patch to mount xtables.lock in the Kustomize / EKS examples. This should be consistent with other services modifying iptables, such as kiam (https://github.com/integrii/kiam/blob/master/deploy/agent.yaml), kube-proxy (https://github.com/vdemeester/kubernetes/blob/master/cluster/addons/kube-proxy/kube-proxy-ds.yaml) and so forth, and help prevent these services from running into race conditions when modifying iptables concurrently.