### PR TITLE
Log res.duration as milliseconds

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -138,10 +138,10 @@ func (h *appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 	h.fn(logger, rw, r)
 	timer.ObserveDuration()
-	latencyNanoseconds := timeSecs * 1e9
+	latencyMilliseconds := timeSecs * 1e3
 	if r.URL.Path != "/healthz" {
-		logger.WithFields(log.Fields{"res.duration": latencyNanoseconds, "res.status": rw.statusCode}).
-			Infof("%s %s (%d) took %f ns", r.Method, r.URL.Path, rw.statusCode, latencyNanoseconds)
+		logger.WithFields(log.Fields{"res.duration": latencyMilliseconds, "res.status": rw.statusCode}).
+			Infof("%s %s (%d) took %f ms", r.Method, r.URL.Path, rw.statusCode, latencyMilliseconds)
 	}
 }
 


### PR DESCRIPTION
This PR makes res.duration expressed in milliseconds instead of nanoseconds.

Actually we are logging response duration as Nanoseconds, this is useless and causing an issue with Go default formatting of numbers to exponential notation:
```
time="2019-07-17T12:07:15Z" level=info msg="GET /latest/meta-data/iam/security-credentials/my-app (200) took 145540128.000000 ns" req.method=GET req.path=/latest/meta-data/iam/security-credentials/my-app req.remote=1.1.1.1 res.duration=1.45540128e+08 res.status=200
```
