### PR TITLE
Update Dockerfile - new version of Alpine to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 
 RUN apk --no-cache add \
     ca-certificates \


### PR DESCRIPTION
Increment Alpine to 3.9 for security reasons