### PR TITLE
Add --disable-user-data & --disable-sensitive-metadata flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ Usage of kube2iam:
       --iam-role-session-ttl                  Length of session when assuming the roles (default 15m)
       --debug                                 Enable debug features
       --default-role string                   Fallback role to use when annotation is not set
+      --disable-sensitive-metadata            Make some sensitive metadata paths return empty strings
+      --disable-user-data                     Make the user-data endpoint return an empty string instead of the host's user-data
       --host-interface string                 Host interface for proxying AWS metadata (default "docker0")
       --host-ip string                        IP address of host
       --iam-role-key string                   Pod annotation key used to retrieve the IAM role (default "iam.amazonaws.com/role")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,8 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.UseRegionalStsEndpoint, "use-regional-sts-endpoint", false, "use the regional sts endpoint if AWS_REGION is set")
 	fs.BoolVar(&s.Verbose, "verbose", false, "Verbose")
 	fs.BoolVar(&s.Version, "version", false, "Print the version and exits")
+	fs.BoolVar(&s.DisableSensitiveMetadata, "disable-sensitive-metadata", false, "Make some sensitive metadata paths return empty strings")
+	fs.BoolVar(&s.DisableUserData, "disable-user-data", false, "Make the user-data endpoint return an empty string instead of the host's user-data")
 }
 
 func main() {


### PR DESCRIPTION
userdata and some metadata paths return more than a pod needs and contents can be safely blanked.

This patch under public domain or BSD license as preferred.