### PR TITLE
Deal with duplicated IP in the pod cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ Usage of kube2iam:
       --metrics-port string                   Metrics server http port (default: same as kube2iam server port) (default "8181")
       --namespace-key string                  Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array) (default "iam.amazonaws.com/allowed-roles")
       --cache-resync-period                   Refresh interval for pod and namespace caches
+      --deal-with-duplicate-ip-in-cache       Queries the k8s api server when the pod's cache contains more than a pod with the same IP
       --namespace-restriction-format string   Namespace Restriction Format (glob/regexp) (default "glob")
       --namespace-restrictions                Enable namespace restrictions
       --node string                           Name of the node where kube2iam is running

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ Usage of kube2iam:
       --metrics-port string                   Metrics server http port (default: same as kube2iam server port) (default "8181")
       --namespace-key string                  Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array) (default "iam.amazonaws.com/allowed-roles")
       --cache-resync-period                   Refresh interval for pod and namespace caches
-      --deal-with-duplicate-ip-in-cache       Queries the k8s api server when the pod's cache contains more than a pod with the same IP
+      --deal-with-duplicated-ip-in-cache       Queries the k8s api server when the pod's cache contains more than a pod with the same IP
       --namespace-restriction-format string   Namespace Restriction Format (glob/regexp) (default "glob")
       --namespace-restrictions                Enable namespace restrictions
       --node string                           Name of the node where kube2iam is running

--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ Usage of kube2iam:
       --metrics-port string                   Metrics server http port (default: same as kube2iam server port) (default "8181")
       --namespace-key string                  Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array) (default "iam.amazonaws.com/allowed-roles")
       --cache-resync-period                   Refresh interval for pod and namespace caches
-      --deal-with-duplicated-ip-in-cache       Queries the k8s api server when the pod's cache contains more than a pod with the same IP
+      --resolve-duplicate-cache-ips           Queries the k8s api server to find the source of truth when the pod cache contains multiple pods with the same IP
       --namespace-restriction-format string   Namespace Restriction Format (glob/regexp) (default "glob")
       --namespace-restrictions                Enable namespace restrictions
       --node string                           Name of the node where kube2iam is running

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.StringVar(&s.NamespaceRestrictionFormat, "namespace-restriction-format", s.NamespaceRestrictionFormat, "Namespace Restriction Format (glob/regexp)")
 	fs.StringVar(&s.NamespaceKey, "namespace-key", s.NamespaceKey, "Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array)")
 	fs.DurationVar(&s.CacheResyncPeriod, "cache-resync-period", s.CacheResyncPeriod, "Kubernetes caches resync period")
+	fs.BoolVar(&s.DealWithDupIP, "deal-with-duplicate-ip-in-cache", false, "Queries the k8s api server when the pod's cache contains more than a pod with the same IP")
 	fs.StringVar(&s.HostIP, "host-ip", s.HostIP, "IP address of host")
 	fs.StringVar(&s.NodeName, "node", s.NodeName, "Name of the node where kube2iam is running")
 	fs.DurationVar(&s.BackoffMaxInterval, "backoff-max-interval", s.BackoffMaxInterval, "Max interval for backoff when querying for role.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.StringVar(&s.NamespaceRestrictionFormat, "namespace-restriction-format", s.NamespaceRestrictionFormat, "Namespace Restriction Format (glob/regexp)")
 	fs.StringVar(&s.NamespaceKey, "namespace-key", s.NamespaceKey, "Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array)")
 	fs.DurationVar(&s.CacheResyncPeriod, "cache-resync-period", s.CacheResyncPeriod, "Kubernetes caches resync period")
-	fs.BoolVar(&s.DealWithDupIP, "deal-with-duplicate-ip-in-cache", false, "Queries the k8s api server when the pod's cache contains more than a pod with the same IP")
+	fs.BoolVar(&s.DealWithDupIP, "deal-with-duplicated-ip-in-cache", false, "Queries the k8s api server when the pod's cache contains more than a pod with the same IP")
 	fs.StringVar(&s.HostIP, "host-ip", s.HostIP, "IP address of host")
 	fs.StringVar(&s.NodeName, "node", s.NodeName, "Name of the node where kube2iam is running")
 	fs.DurationVar(&s.BackoffMaxInterval, "backoff-max-interval", s.BackoffMaxInterval, "Max interval for backoff when querying for role.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.StringVar(&s.NamespaceRestrictionFormat, "namespace-restriction-format", s.NamespaceRestrictionFormat, "Namespace Restriction Format (glob/regexp)")
 	fs.StringVar(&s.NamespaceKey, "namespace-key", s.NamespaceKey, "Namespace annotation key used to retrieve the IAM roles allowed (value in annotation should be json array)")
 	fs.DurationVar(&s.CacheResyncPeriod, "cache-resync-period", s.CacheResyncPeriod, "Kubernetes caches resync period")
-	fs.BoolVar(&s.DealWithDupIP, "deal-with-duplicated-ip-in-cache", false, "Queries the k8s api server when the pod's cache contains more than a pod with the same IP")
+	fs.BoolVar(&s.ResolveDupIPs, "resolve-duplicate-cache-ips", false, "Queries the k8s api server to find the source of truth when the pod cache contains multiple pods with the same IP")
 	fs.StringVar(&s.HostIP, "host-ip", s.HostIP, "IP address of host")
 	fs.StringVar(&s.NodeName, "node", s.NodeName, "Name of the node where kube2iam is running")
 	fs.DurationVar(&s.BackoffMaxInterval, "backoff-max-interval", s.BackoffMaxInterval, "Max interval for backoff when querying for role.")

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -119,8 +119,6 @@ func (k8s *Client) PodByIP(IP string) (*v1.Pod, error) {
 // If the indexed pods all have HostNetwork = true the function return nil and the error message.
 // If we retrive a running pod that doesn't have HostNetwork = true and it is in Running state will return that.
 func dealWithDuplicatedIP(k8s *Client, IP string) (*v1.Pod, error) {
-	error := fmt.Errorf("more than a pod with the same IP has been indexed, this can happen when pods have hostNetwork: true")
-
 	runningPodList, err := k8s.CoreV1().Pods("").List(v1.ListOptions{
 		FieldSelector: selector.OneTermEqualSelector("status.podIP", IP).String(),
 	})
@@ -134,6 +132,7 @@ func dealWithDuplicatedIP(k8s *Client, IP string) (*v1.Pod, error) {
 			return &pod, nil
 		}
 	}
+	error := fmt.Errorf("more than a pod with the same IP has been indexed, this can happen when pods have hostNetwork: true")
 	return nil, error
 }
 

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -118,7 +118,6 @@ func (k8s *Client) PodByIP(IP string, dealWithDupIP bool) (*v1.Pod, error) {
 // If the indexed pods all have HostNetwork = true the function return nil and the error message.
 // If we retrive a running pod that doesn't have HostNetwork = true and it is in Running state will return that.
 func DealWithDuplicatedIP(k8s *Client, IP string) (*v1.Pod, error) {
-	metrics.K8sAPIDupInvokeCount.Inc()
 	error := fmt.Errorf("more than a pod with the same IP has been indexed, this can happen when pods have hostNetwork: true")
 
 	runningPodList, err := k8s.CoreV1().Pods("").List(v1.ListOptions{

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/jtblin/kube2iam"
+	"github.com/jtblin/kube2iam/metrics"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/pkg/api/v1"
@@ -134,6 +135,7 @@ func DealWithDuplicatedIP(pods []interface{}, k8s *Client) (*v1.Pod, error) {
 		livePods := make([]*v1.Pod, len(podNames))
 		for i := 0; i < len(podNames); i++ {
 			livePod, err := k8s.CoreV1().Pods(podNamespaces[i]).Get(podNames[i])
+			metrics.K8sAPIDupReqCount.Inc()
 			if err != nil {
 				//pod could not exist, error is expected here
 				continue

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -129,7 +129,7 @@ func dealWithDuplicatedIP(k8s *Client, IP string) (*v1.Pod, error) {
 		return nil, fmt.Errorf("dealWithDuplicatedIP: Error retriving the pod with IP %s from the k8s api", IP)
 	}
 	for _, pod := range runningPodList.Items {
-		if !pod.Spec.HostNetwork && "Running" == string(pod.Status.Phase) {
+		if !pod.Spec.HostNetwork && string(pod.Status.Phase) == "Running" {
 			metrics.K8sAPIDupReqSuccesCount.Inc()
 			return &pod, nil
 		}

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -108,17 +108,17 @@ func (k8s *Client) PodByIP(IP string) (*v1.Pod, error) {
 		}
 		return nil, fmt.Errorf("%d pods (%v) with the ip %s indexed", len(pods), podNames, IP)
 	}
-	pod, err := DealWithDuplicatedIP(k8s, IP)
+	pod, err := dealWithDuplicatedIP(k8s, IP)
 	if err != nil {
 		return nil, err
 	}
 	return pod, nil
 }
 
-// DealWithDuplicatedIP queries the k8s api server trying to make a decision based on NON cached data
+// dealWithDuplicatedIP queries the k8s api server trying to make a decision based on NON cached data
 // If the indexed pods all have HostNetwork = true the function return nil and the error message.
 // If we retrive a running pod that doesn't have HostNetwork = true and it is in Running state will return that.
-func DealWithDuplicatedIP(k8s *Client, IP string) (*v1.Pod, error) {
+func dealWithDuplicatedIP(k8s *Client, IP string) (*v1.Pod, error) {
 	error := fmt.Errorf("more than a pod with the same IP has been indexed, this can happen when pods have hostNetwork: true")
 
 	runningPodList, err := k8s.CoreV1().Pods("").List(v1.ListOptions{
@@ -126,7 +126,7 @@ func DealWithDuplicatedIP(k8s *Client, IP string) (*v1.Pod, error) {
 	})
 	metrics.K8sAPIDupReqCount.Inc()
 	if err != nil {
-		return nil, fmt.Errorf("DealWithDuplicatedIP: Error retriving the pod with IP %s from the k8s api", IP)
+		return nil, fmt.Errorf("dealWithDuplicatedIP: Error retriving the pod with IP %s from the k8s api", IP)
 	}
 	for _, pod := range runningPodList.Items {
 		if !pod.Spec.HostNetwork && "Running" == string(pod.Status.Phase) {

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -153,7 +153,7 @@ func (k8s *Client) NamespaceByName(namespaceName string) (*v1.Namespace, error) 
 }
 
 // NewClient returns a new kubernetes client.
-func NewClient(host, token, nodeName string, insecure bool, dealWithDupIP bool) (*Client, error) {
+func NewClient(host, token, nodeName string, insecure, dealWithDupIP bool) (*Client, error) {
 	var config *rest.Config
 	var err error
 	if host != "" && token != "" {

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -27,7 +27,7 @@ type RoleMapper struct {
 
 type store interface {
 	ListPodIPs() []string
-	PodByIP(string, bool) (*v1.Pod, error)
+	PodByIP(string) (*v1.Pod, error)
 	ListNamespaces() []string
 	NamespaceByName(string) (*v1.Namespace, error)
 }
@@ -40,8 +40,8 @@ type RoleMappingResult struct {
 }
 
 // GetRoleMapping returns the normalized iam RoleMappingResult based on IP address
-func (r *RoleMapper) GetRoleMapping(IP string, dealWithDupIP bool) (*RoleMappingResult, error) {
-	pod, err := r.store.PodByIP(IP, dealWithDupIP)
+func (r *RoleMapper) GetRoleMapping(IP string) (*RoleMappingResult, error) {
+	pod, err := r.store.PodByIP(IP)
 	// If attempting to get a Pod that maps to multiple IPs
 	if err != nil {
 		return nil, err
@@ -61,8 +61,8 @@ func (r *RoleMapper) GetRoleMapping(IP string, dealWithDupIP bool) (*RoleMapping
 }
 
 // GetExternalIDMapping returns the externalID based on IP address
-func (r *RoleMapper) GetExternalIDMapping(IP string, dealWithDupIP bool) (string, error) {
-	pod, err := r.store.PodByIP(IP, dealWithDupIP)
+func (r *RoleMapper) GetExternalIDMapping(IP string) (string, error) {
+	pod, err := r.store.PodByIP(IP)
 	// If attempting to get a Pod that maps to multiple IPs
 	if err != nil {
 		return "", err
@@ -138,8 +138,7 @@ func (r *RoleMapper) DumpDebugInfo() map[string]interface{} {
 
 	for _, ip := range r.store.ListPodIPs() {
 		// When pods have `hostNetwork: true` they share an IP and we receive an error
-		// passing false to PodByIP in this case we don't want to query the k8s api server
-		if pod, err := r.store.PodByIP(ip, false); err == nil {
+		if pod, err := r.store.PodByIP(ip); err == nil {
 			namespacesByIP[ip] = pod.Namespace
 			if role, ok := pod.GetAnnotations()[r.iamRoleKey]; ok {
 				rolesByIP[ip] = role

--- a/mappings/mapper_test.go
+++ b/mappings/mapper_test.go
@@ -388,7 +388,7 @@ type storeMock struct {
 func (k *storeMock) ListPodIPs() []string {
 	return nil
 }
-func (k *storeMock) PodByIP(string, bool) (*v1.Pod, error) {
+func (k *storeMock) PodByIP(string) (*v1.Pod, error) {
 	return nil, nil
 }
 func (k *storeMock) ListNamespaces() []string {

--- a/mappings/mapper_test.go
+++ b/mappings/mapper_test.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/client-go/pkg/api/v1"
-
 	"github.com/jtblin/kube2iam/iam"
+	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 const (
@@ -389,7 +388,7 @@ type storeMock struct {
 func (k *storeMock) ListPodIPs() []string {
 	return nil
 }
-func (k *storeMock) PodByIP(string) (*v1.Pod, error) {
+func (k *storeMock) PodByIP(string, bool) (*v1.Pod, error) {
 	return nil, nil
 }
 func (k *storeMock) ListNamespaces() []string {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -64,13 +64,13 @@ var (
 		},
 	)
 
-	// K8sAPIDupReqSuccesCount tracks total number of times we successfully retrive the pod from the K8s Api.
+	// K8sAPIDupReqSuccesCount tracks total number of times we successfully retrieve the pod from the K8s Api.
 	K8sAPIDupReqSuccesCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: "iam",
 			Name:      "k8s_dup_req_success_count",
-			Help:      "Total number of times we successfully retrive the pod from the K8s Api.",
+			Help:      "Total number of times we successfully retrieve the pod from the K8s Api.",
 		},
 	)
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -54,16 +54,6 @@ var (
 		},
 	)
 
-	// K8sAPIDupInvokeCount tracks total number of times the dup function is invoked.
-	K8sAPIDupInvokeCount = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: "iam",
-			Name:      "k8s_dup_invoke_count",
-			Help:      "Total number of times the dup function is invoked.",
-		},
-	)
-
 	// K8sAPIDupReqCount tracks total number of K8s Api requests performed when duplicated pods are identified in the cache.
 	K8sAPIDupReqCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
@@ -145,7 +135,6 @@ var (
 func init() {
 	prometheus.MustRegister(IamRequestSec)
 	prometheus.MustRegister(IamCacheHitCount)
-	prometheus.MustRegister(K8sAPIDupInvokeCount)
 	prometheus.MustRegister(K8sAPIDupReqCount)
 	prometheus.MustRegister(K8sAPIDupReqSuccesCount)
 	prometheus.MustRegister(PodNotFoundInCache)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -60,7 +60,7 @@ var (
 			Namespace: namespace,
 			Subsystem: "iam",
 			Name:      "k8s_dup_req_count",
-			Help:      "Total number of K8s Api requests performed when duplicated pods are identified in the cache.",
+			Help:      "Total number of K8s API requests performed when duplicated pods are identified in the cache.",
 		},
 	)
 
@@ -70,7 +70,7 @@ var (
 			Namespace: namespace,
 			Subsystem: "iam",
 			Name:      "k8s_dup_req_success_count",
-			Help:      "Total number of times we successfully retrieve the pod from the K8s Api.",
+			Help:      "Total number of times we successfully retrieve the pod from the K8s API.",
 		},
 	)
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -54,6 +54,16 @@ var (
 		},
 	)
 
+	// K8sAPIDupReqCount tracks total number of K8s Api requests performed when duplicated pods are identified in the cache.
+	K8sAPIDupReqCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "iam",
+			Name:      "k8s_api_dup_req_count",
+			Help:      "Total number of K8s Api requests performed when duplicated pods are identified in the cache.",
+		},
+	)
+
 	// HTTPRequestSec tracks timing of served HTTP requests.
 	HTTPRequestSec = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -105,6 +115,7 @@ var (
 func init() {
 	prometheus.MustRegister(IamRequestSec)
 	prometheus.MustRegister(IamCacheHitCount)
+	prometheus.MustRegister(K8sAPIDupReqCount)
 	prometheus.MustRegister(HTTPRequestSec)
 	prometheus.MustRegister(HealthcheckStatus)
 	prometheus.MustRegister(Info)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -54,13 +54,43 @@ var (
 		},
 	)
 
+	// K8sAPIDupInvokeCount tracks total number of times the dup function is invoked.
+	K8sAPIDupInvokeCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "iam",
+			Name:      "k8s_dup_invoke_count",
+			Help:      "Total number of times the dup function is invoked.",
+		},
+	)
+
 	// K8sAPIDupReqCount tracks total number of K8s Api requests performed when duplicated pods are identified in the cache.
 	K8sAPIDupReqCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: "iam",
-			Name:      "k8s_api_dup_req_count",
+			Name:      "k8s_dup_req_count",
 			Help:      "Total number of K8s Api requests performed when duplicated pods are identified in the cache.",
+		},
+	)
+
+	// K8sAPIDupReqSuccesCount tracks total number of times we successfully retrive the pod from the K8s Api.
+	K8sAPIDupReqSuccesCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "iam",
+			Name:      "k8s_dup_req_success_count",
+			Help:      "Total number of times we successfully retrive the pod from the K8s Api.",
+		},
+	)
+
+	// PodNotFoundInCache tracks total number of times we don't have the pod info in the cache.
+	PodNotFoundInCache = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "iam",
+			Name:      "k8s_pod_not_in_pod_cache",
+			Help:      "Total number of times we don't have the pod info in the cache.",
 		},
 	)
 
@@ -115,7 +145,10 @@ var (
 func init() {
 	prometheus.MustRegister(IamRequestSec)
 	prometheus.MustRegister(IamCacheHitCount)
+	prometheus.MustRegister(K8sAPIDupInvokeCount)
 	prometheus.MustRegister(K8sAPIDupReqCount)
+	prometheus.MustRegister(K8sAPIDupReqSuccesCount)
+	prometheus.MustRegister(PodNotFoundInCache)
 	prometheus.MustRegister(HTTPRequestSec)
 	prometheus.MustRegister(HealthcheckStatus)
 	prometheus.MustRegister(Info)

--- a/namespace.go
+++ b/namespace.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 // NamespaceHandler outputs change events from K8.

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -3,7 +3,7 @@ package kube2iam
 import (
 	"testing"
 
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 func TestGetNamespaceRoleAnnotation(t *testing.T) {

--- a/pod.go
+++ b/pod.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -63,10 +63,10 @@ type Server struct {
 	NodeName                   string
 	NamespaceKey               string
 	CacheResyncPeriod          time.Duration
-	DealWithDupIP              bool
 	LogLevel                   string
 	LogFormat                  string
 	NamespaceRestrictionFormat string
+	DealWithDupIP              bool
 	UseRegionalStsEndpoint     bool
 	AddIPTablesRule            bool
 	AutoDiscoverBaseArn        bool

--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,7 @@ const (
 	defaultMetadataAddress            = "169.254.169.254"
 	defaultNamespaceKey               = "iam.amazonaws.com/allowed-roles"
 	defaultCacheResyncPeriod          = 30 * time.Minute
+	defaultDealWithDupIP              = false
 	defaultNamespaceRestrictionFormat = "glob"
 	healthcheckInterval               = 30 * time.Second
 )
@@ -62,6 +63,7 @@ type Server struct {
 	NodeName                   string
 	NamespaceKey               string
 	CacheResyncPeriod          time.Duration
+	DealWithDupIP              bool
 	LogLevel                   string
 	LogFormat                  string
 	NamespaceRestrictionFormat string
@@ -170,7 +172,7 @@ func (s *Server) getRoleMapping(IP string) (*mappings.RoleMappingResult, error) 
 	var roleMapping *mappings.RoleMappingResult
 	var err error
 	operation := func() error {
-		roleMapping, err = s.roleMapper.GetRoleMapping(IP)
+		roleMapping, err = s.roleMapper.GetRoleMapping(IP, s.DealWithDupIP)
 		return err
 	}
 
@@ -190,7 +192,7 @@ func (s *Server) getExternalIDMapping(IP string) (string, error) {
 	var externalID string
 	var err error
 	operation := func() error {
-		externalID, err = s.roleMapper.GetExternalIDMapping(IP)
+		externalID, err = s.roleMapper.GetExternalIDMapping(IP, s.DealWithDupIP)
 		return err
 	}
 
@@ -439,6 +441,7 @@ func NewServer() *Server {
 		MetadataAddress:            defaultMetadataAddress,
 		NamespaceKey:               defaultNamespaceKey,
 		CacheResyncPeriod:          defaultCacheResyncPeriod,
+		DealWithDupIP:              defaultDealWithDupIP,
 		NamespaceRestrictionFormat: defaultNamespaceRestrictionFormat,
 		HealthcheckFailReason:      "Healthcheck not yet performed",
 		IAMRoleSessionTTL:          defaultIAMRoleSessionTTL,

--- a/server/server.go
+++ b/server/server.go
@@ -172,7 +172,7 @@ func (s *Server) getRoleMapping(IP string) (*mappings.RoleMappingResult, error) 
 	var roleMapping *mappings.RoleMappingResult
 	var err error
 	operation := func() error {
-		roleMapping, err = s.roleMapper.GetRoleMapping(IP, s.DealWithDupIP)
+		roleMapping, err = s.roleMapper.GetRoleMapping(IP)
 		return err
 	}
 
@@ -192,7 +192,7 @@ func (s *Server) getExternalIDMapping(IP string) (string, error) {
 	var externalID string
 	var err error
 	operation := func() error {
-		externalID, err = s.roleMapper.GetExternalIDMapping(IP, s.DealWithDupIP)
+		externalID, err = s.roleMapper.GetExternalIDMapping(IP)
 		return err
 	}
 
@@ -371,7 +371,7 @@ func write(logger *log.Entry, w http.ResponseWriter, s string) {
 
 // Run runs the specified Server.
 func (s *Server) Run(host, token, nodeName string, insecure bool) error {
-	k, err := k8s.NewClient(host, token, nodeName, insecure)
+	k, err := k8s.NewClient(host, token, nodeName, insecure, s.DealWithDupIP)
 	if err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -37,7 +37,7 @@ const (
 	defaultMetadataAddress            = "169.254.169.254"
 	defaultNamespaceKey               = "iam.amazonaws.com/allowed-roles"
 	defaultCacheResyncPeriod          = 30 * time.Minute
-	defaultDealWithDupIP              = false
+	defaultResolveDupIPs              = false
 	defaultNamespaceRestrictionFormat = "glob"
 	healthcheckInterval               = 30 * time.Second
 )
@@ -66,7 +66,7 @@ type Server struct {
 	LogLevel                   string
 	LogFormat                  string
 	NamespaceRestrictionFormat string
-	DealWithDupIP              bool
+	ResolveDupIPs              bool
 	UseRegionalStsEndpoint     bool
 	AddIPTablesRule            bool
 	AutoDiscoverBaseArn        bool
@@ -371,7 +371,7 @@ func write(logger *log.Entry, w http.ResponseWriter, s string) {
 
 // Run runs the specified Server.
 func (s *Server) Run(host, token, nodeName string, insecure bool) error {
-	k, err := k8s.NewClient(host, token, nodeName, insecure, s.DealWithDupIP)
+	k, err := k8s.NewClient(host, token, nodeName, insecure, s.ResolveDupIPs)
 	if err != nil {
 		return err
 	}
@@ -441,7 +441,7 @@ func NewServer() *Server {
 		MetadataAddress:            defaultMetadataAddress,
 		NamespaceKey:               defaultNamespaceKey,
 		CacheResyncPeriod:          defaultCacheResyncPeriod,
-		DealWithDupIP:              defaultDealWithDupIP,
+		ResolveDupIPs:              defaultResolveDupIPs,
 		NamespaceRestrictionFormat: defaultNamespaceRestrictionFormat,
 		HealthcheckFailReason:      "Healthcheck not yet performed",
 		IAMRoleSessionTTL:          defaultIAMRoleSessionTTL,


### PR DESCRIPTION
Trying to definitely fix issue https://github.com/jtblin/kube2iam/issues/244 maintaining retro compatibility.

When the flag is set to true (default is false) in case the cache lookups returns more than 1 result,
a query to the API server is issued and **a pod is returned only if it is running and not with host network**.

I've also added some metrics in order to track the amount of requests that are performed to the api server.

@Jacobious52 or any other maintainers can you please check this out?