### PR TITLE
Add option to use base-arn verbatim, without adding extra forward sla…

### DIFF
--- a/iam/arn_test.go
+++ b/iam/arn_test.go
@@ -11,6 +11,7 @@ func TestIsValidBaseARN(t *testing.T) {
 		"arn:aws:iam::123456789012:role/path/sub-path",
 		"arn:aws:iam::123456789012:role/path/sub_path",
 		"arn:aws:iam::123456789012:role/subdomain.domain",
+		"arn:aws:iam::123456789012:role/cluster1-",
 		"arn:aws:iam::123456789012:role",
 		"arn:aws:iam::123456789012:role/",
 		"arn:aws:iam::123456789012:role-part",

--- a/server/server.go
+++ b/server/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	AppPort                    string
 	MetricsPort                string
 	BaseRoleARN                string
+	BaseRoleARNVerbatim        string
 	DefaultIAMRole             string
 	IAMRoleKey                 string
 	IAMExternalID              string


### PR DESCRIPTION
…shes

Fixes https://github.com/jtblin/kube2iam/issues/256

This will allow using prefixes that are not ending with / and it will not break existing installations.

Probably, the better fix is to not add `/` by default, but it breaks current behavior. 