### PR TITLE
Upgrade openssl version from 1.1.1d to 1.1.1g to fix CVE-2020-1967

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,8 @@ FROM alpine:3.11.3
 RUN apk --no-cache add \
     ca-certificates \
     iptables
+RUN apk upgrade --update-cache --available && \
+    apk add openssl && \
+    rm -rf /var/cache/apk/*
 COPY --from=BUILDER /go/src/github.com/jtblin/kube2iam/build/bin/linux/kube2iam /bin/kube2iam
 ENTRYPOINT ["kube2iam"]


### PR DESCRIPTION
This fixes #285 
Upgrade openssl version from **1.1.1d** to **1.1.1g** to fix vulnerability: [CVE-2020-1967](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1967).

Signed-off-by: Brenda Wang <brwang@guidewire.com>