### PR TITLE
Add Pod lifecycle to remove redirect iptables rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ different than `docker0` depending on which virtual network you use e.g.
 * for [OpenShift](https://www.openshift.org/) use `tun0`
 * for [Cilium](https://www.cilium.io) use `lxc+`
 
+**Warning**: It is important ensure the iptables rule will be deleted when you delete the DaemonSet. Below is the command proposal to deal with it, we recommend to use the comand in the Pod Lifecycle:
+
+```bash
+eval `iptables-save | grep 169.254.169.254 | sed s/-A/'iptables -t nat -D'/g`
+```
+
 ```yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -192,6 +198,12 @@ spec:
               name: http
           securityContext:
             privileged: true
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  "/bin/sh", "-c", "eval `iptables-save | grep 169.254.169.254 | sed s/-A/'iptables -t nat -D'/g`"
+                ]
 ```
 
 ### kubernetes annotation

--- a/charts/kube2iam/templates/daemonset.yaml
+++ b/charts/kube2iam/templates/daemonset.yaml
@@ -105,6 +105,8 @@ spec:
         {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          lifecycle:
+{{ toYaml .Values.lifecycle | indent 12 }}
         {{- if .Values.host.iptables }}
           securityContext:
             privileged: true

--- a/charts/kube2iam/values.yaml
+++ b/charts/kube2iam/values.yaml
@@ -97,6 +97,14 @@ resources: {}
   #   cpu: 4m
   #   memory: 16Mi
 
+lifecycle:
+  preStop:
+    exec:
+      command: [
+        "/bin/sh", "-c", "eval `iptables-save | grep 169.254.169.254 | sed s/-A/'iptables -t nat -D'/g`"
+      ]
+
+
 ## Strategy for DaemonSet updates (requires Kubernetes 1.6+)
 ## Ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
 ##

--- a/examples/eks-example.yml
+++ b/examples/eks-example.yml
@@ -74,6 +74,12 @@ spec:
               name: http
           securityContext:
             privileged: true
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  "/bin/sh", "-c", "eval `iptables-save | grep 169.254.169.254 | sed s/-A/'iptables -t nat -D'/g`"
+                ]              
           volumeMounts:
             - mountPath: /run/xtables.lock
               name: xtables-lock


### PR DESCRIPTION
Implement Pod lifecycle to remove redirect iptables rules to avoid
traffic be redirected to one port service that is not working anymore.

It is implemented using Pod Lifecycle preStop to remove the rule when
the kube2iam DaemonSet is deleted or the pod die somehow.