### PR TITLE
[helm] Add maxUnavailable option for rolling updates

### DIFF
--- a/charts/kube2iam/Chart.yaml
+++ b/charts/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.5.2
+version: 2.6.0
 appVersion: 0.10.9
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/charts/kube2iam/README.md
+++ b/charts/kube2iam/README.md
@@ -74,6 +74,7 @@ Parameter | Description | Default
 `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
 `resources` | pod resource requests & limits | `{}`
 `updateStrategy` | Strategy for DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
+`maxUnavailable` | Maximum number of pods to be unavailable during an update. It can be an absolute number or a percentage. | `1`
 `verbose` | Enable verbose output | `false`
 `tolerations` | List of node taints to tolerate (requires Kubernetes 1.6+) | `[]`
 `aws.secret_key` | The value to use for AWS_SECRET_ACCESS_KEY | `""`

--- a/charts/kube2iam/templates/daemonset.yaml
+++ b/charts/kube2iam/templates/daemonset.yaml
@@ -127,4 +127,8 @@ spec:
 {{- if semverCompare "^1.6-0" .Capabilities.KubeVersion.GitVersion }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
+    {{- if eq "RollingUpdate" .Values.updateStrategy }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.maxUnavailable }}
+    {{- end }}
 {{- end }}

--- a/charts/kube2iam/values.yaml
+++ b/charts/kube2iam/values.yaml
@@ -102,6 +102,11 @@ resources: {}
 ##
 updateStrategy: OnDelete
 
+## Maximum number of Pods that can be unavailable during the update process
+## when using updateStrategy: RollingUpdate
+## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable
+maxUnavailable: 1
+
 verbose: false
 
 tolerations: []


### PR DESCRIPTION
Allow user to set maxUnavailable option for rolling updates in order
to speed up deployment times on large clusters.