### PR TITLE
Build and push docker image for arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,28 @@ services:
 go:
   - 1.14.x
 
+arch:
+  - amd64
+  - arm64
+
 os:
   - linux
+
+jobs:
+  include:
+   - os: linux
+     arch: amd64
+   - os: linux
+     arch: arm64
+   - stage: Push Docker manifest
+     env:
+       - DOCKER_CLI_EXPERIMENTAL=enabled
+     script:
+       - if [ "$TRAVIS_OS_NAME" == "linux" -a ! -z "$TRAVIS_TAG" ]; then
+           echo "Executing release-manifest on tag build $TRAVIS_TAG";
+           docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+           make release-manifest;
+         fi
 
 before_install:
   - go get -v github.com/mattn/goveralls
@@ -25,10 +45,10 @@ script:
   - make coveralls
 
 after_success:
-  - if [ "$TRAVIS_OS_NAME" == "linux" -a ! -z "$TRAVIS_TAG" ]; then
+  - if [ "$TRAVIS_BUILD_STAGE_NAME" == "test" -a "$TRAVIS_OS_NAME" == "linux" -a ! -z "$TRAVIS_TAG" ]; then
     echo "Executing release on tag build $TRAVIS_TAG";
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-    make release;
+    ARCH=linux CPU_ARCH="$TRAVIS_CPU_ARCH" make release;
     else
     echo "Not executing release on non-tag build";
     fi


### PR DESCRIPTION
This adds support for building Docker images for arm64 architecture.

Tested by pushing a tag and publishing the manifest to docker hub.
- Build: https://travis-ci.org/github/hligit/kube2iam/builds/748263791
- Manifest: https://hub.docker.com/layers/htli/kube2iam/hlitest/images/sha256-a05cc00c5fb1cbfed2092795293261dc85c6055f9f3505d0ea625ab3b0c1f198