### PR TITLE
Use Alpine 3.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV CGO_ENABLED=0
 COPY . ./
 RUN make setup && make build
 
-FROM alpine:3.11.3
+FROM alpine:3.12.1
 RUN apk --no-cache add \
     ca-certificates \
     iptables


### PR DESCRIPTION
Bump Alpine to v3.12.1 to include openssl 1.1.1g for fixing [CVE-2020-1967](https://nvd.nist.gov/vuln/detail/CVE-2020-1967).