### PR TITLE
Bump Go to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.0 AS BUILDER
+FROM golang:1.16.0 AS BUILDER
 WORKDIR /go/src/github.com/jtblin/kube2iam
 ENV ARCH=linux
 ENV CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ GOLANGCI_LINT_DEADLINE ?= 180
 DOCKER_BUILD_FLAGS :=
 
 setup:
-	go get -v -u golang.org/x/tools/cmd/goimports
+	go install golang.org/x/tools/cmd/goimports
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.23.8
-	go get -v -u github.com/jstemmer/go-junit-report
-	go get -v github.com/mattn/goveralls
+	go install github.com/jstemmer/go-junit-report
+	go install github.com/mattn/goveralls
 
 build: *.go fmt
 	go build -o build/bin/$(ARCH)/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) github.com/jtblin/$(BINARY_NAME)/cmd


### PR DESCRIPTION
#### What this PR does / why we need it:
* Bumps go to 1.16, mitigating https://github.com/golang/go/issues/37436
* Uses `go install` instead of `go get` for installing build tools.
>go install now accepts arguments with version suffixes (for example, go install example.com/cmd@v1.0.0). This causes go install to build and install packages in module-aware mode, ignoring the go.mod file in the current directory or any parent directory, if there is one. This is useful for installing executables without affecting the dependencies of the main module. [source]

[SOURCE]: https://golang.org/doc/go1.16#go-command