### PR TITLE
Add readiness probe to helm chart

### DIFF
--- a/charts/kube2iam/Chart.yaml
+++ b/charts/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.6.0
+version: 3.0.0
 appVersion: 0.10.9
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/charts/kube2iam/README.md
+++ b/charts/kube2iam/README.md
@@ -54,6 +54,12 @@ Parameter | Description | Default
 `image.tag` | Image tag | `0.10.7`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.pullSecrets` | Image pull secrets | `[]`
+`livenessProbe.enabled`|Enable/disable pod liveness probe|`true`
+`livenessProbe.initialDelaySeconds`|Liveness probe initial delay|`30`
+`livenessProbe.periodSeconds`|Liveness probe check inteval|`5`
+`livenessProbe.successThreshold`|Liveness probe success threshold|`1`
+`livenessProbe.failureThreshold`|Liveness probe fail threshold|`3`
+`livenessProbe.timeoutSeconds`|Livenees probe timeout|`1`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to be added to pods | `{}`
 `priorityClassName` | priorityClassName to be added to pods | `{}`
@@ -64,14 +70,14 @@ Parameter | Description | Default
 `prometheus.serviceMonitor.interval` | Interval at which the metrics endpoint is scraped | `10s`
 `prometheus.serviceMonitor.namespace` | An alternative namespace in which to install the ServiceMonitor | `""`
 `prometheus.serviceMonitor.labels` | Labels to add to the ServiceMonitor | `{}`
-`probe.enabled`|Enable/disable pod liveness probe|`true`
-`probe.initialDelaySeconds`|Liveness probe initial delay|`30`
-`probe.periodSeconds`|Liveness probe check inteval|`5`
-`probe.successThreshold`|Liveness probe success threshold|`1`
-`probe.failureThreshold`|Liveness probe fail threshold|`3`
-`probe.timeoutSeconds`|Livenees probe timeout|`1`
 `rbac.create` | If true, create & use RBAC resources | `false`
 `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
+`readinessProbe.enabled`|Enable/disable pod readiness probe|`true`
+`readinessProbe.initialDelaySeconds`|Readiness probe initial delay|`0
+`readinessProbe.periodSeconds`|Readiness probe check inteval|`5`
+`readinessProbe.successThreshold`|Readiness probe success threshold|`1`
+`readinessProbe.failureThreshold`|Readiness probe fail threshold|`3`
+`readinessProbe.timeoutSeconds`|Livenees probe timeout|`1`
 `resources` | pod resource requests & limits | `{}`
 `updateStrategy` | Strategy for DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
 `maxUnavailable` | Maximum number of pods to be unavailable during an update. It can be an absolute number or a percentage. | `1`

--- a/charts/kube2iam/templates/daemonset.yaml
+++ b/charts/kube2iam/templates/daemonset.yaml
@@ -91,17 +91,27 @@ spec:
               containerPort: {{ .Values.prometheus.metricsPort }}
             {{- end}}
             {{- end}}
-        {{- if .Values.probe.enabled }}
+        {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.host.port }}
               scheme: HTTP
-            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probe.periodSeconds }}
-            successThreshold: {{ .Values.probe.successThreshold }}
-            failureThreshold: {{ .Values.probe.failureThreshold }}
-            timeoutSeconds: {{ .Values.probe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.host.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/charts/kube2iam/templates/daemonset.yaml
+++ b/charts/kube2iam/templates/daemonset.yaml
@@ -102,6 +102,8 @@ spec:
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/kube2iam/values.yaml
+++ b/charts/kube2iam/values.yaml
@@ -72,9 +72,16 @@ priorityClassName: ""
 
 podLabels: {}
 
-probe:
+livenessProbe:
   enabled: true
   initialDelaySeconds: 30
+  periodSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+  timeoutSeconds: 1
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 0
   periodSeconds: 5
   successThreshold: 1
   failureThreshold: 3


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds a readiness probe. This is important in case it's needed kube2iam to be in ready status before scheduling any other workload that relies on kube2iam.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes:

#### Checklist chart
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
