### PR TITLE
Allow negation of interfaces for iptables rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ different than `docker0` depending on which virtual network you use e.g.
 * for kops (on kubenet), use `cbr0`
 * for CNI, use `cni0`
 * for [EKS](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html)/[amazon-vpc-cni-k8s](https://github.com/aws/amazon-vpc-cni-k8s), even with calico installed uses `eni+`. (Each pod gets an interface like `eni4c0e15dfb05`)
+  * If using security groups per pod however, you will need to instead use `!eth0` as pods making use of security groups per pod [will use](https://aws.amazon.com/blogs/containers/introducing-security-groups-for-pods/) `vlan` interfaces as well as the `eni+` interfaces used for other pods.
 * for weave use `weave`
 * for flannel use `cni0`
 * for [kube-router](https://github.com/cloudnativelabs/kube-router) use `kube-bridge`

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -36,6 +36,40 @@ func TestCheckInterfaceExistsPassesWithPlus(t *testing.T) {
 	}
 }
 
+func TestCheckInterfaceExistsPassesWithNegated(t *testing.T) {
+	var ifc string
+	switch os := runtime.GOOS; os {
+	case "darwin":
+		ifc = "!lo0"
+	case "linux":
+		ifc = "!lo"
+	default:
+		// everything else that we don't know or care about...fail
+		ifc = "!unknown"
+		t.Fatalf("%s OS '%s'\n", ifc, os)
+	}
+	if err := checkInterfaceExists(ifc); err != nil {
+		t.Error("Should pass with negated interface(s). Interface received:", ifc)
+	}
+}
+
+func TestCheckInterfaceExistsFailsWithDoubleNegated(t *testing.T) {
+	var ifc string
+	switch os := runtime.GOOS; os {
+	case "darwin":
+		ifc = "!!lo0"
+	case "linux":
+		ifc = "!!lo"
+	default:
+		// everything else that we don't know or care about...fail
+		ifc = "!!unknown"
+		t.Fatalf("%s OS '%s'\n", ifc, os)
+	}
+	if err := checkInterfaceExists(ifc); err == nil {
+		t.Error("Should fail with invalid interface. Interface received:", ifc)
+	}
+}
+
 func TestAddRule(t *testing.T) {
 	t.Skip()
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

* Allows negation of interfaces in iptables rules

As per the AWS docs for AWS VPC CNI [security groups per pod](https://aws.amazon.com/blogs/containers/introducing-security-groups-for-pods/), pods using security groups per pod will be assigned `vlan*` interfaces on the nodes, not `eni*` interfaces as with pods not making use of this functionality. This means that currently kube2iam can either be set up to capture IAM traffic from pods making use of security groups per pod, or those not using it, but not both, unless you pass the interface as `+`, thus capturing all EC2 metadata traffic for the entire host.

Based on existing functionality to allow negative matching of interfaces in [uswitch/kiam](https://github.com/uswitch/kiam) introduced by https://github.com/uswitch/kiam/pull/54

#### Which issue this PR fixes
  - fixes #303 

#### Special notes:

#### Checklist chart

N/A
