### PR TITLE
update to image 0.10.11 in helm chart

### DIFF
--- a/charts/kube2iam/Chart.yaml
+++ b/charts/kube2iam/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kube2iam
-version: 3.0.0
-appVersion: 0.10.9
+version: 3.1.0
+appVersion: 0.10.11
 description: Provide IAM credentials to pods based on annotations.
 keywords:
 - kube2iam

--- a/charts/kube2iam/values.yaml
+++ b/charts/kube2iam/values.yaml
@@ -37,7 +37,7 @@ prometheus:
 
 image:
   repository: jtblin/kube2iam
-  tag: 0.10.9
+  tag: 0.10.11
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixed to use a image that supports IMDSv2.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #328 

#### Special notes:

Use the latest 0.10.11 available on Docker Hub.

#### Checklist chart
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

