### PR TITLE
chore: bump alpine version to resolve vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV CGO_ENABLED=0
 COPY . ./
 RUN make setup && make build
 
-FROM alpine:3.14.3
+FROM alpine:3.17.1
 RUN apk --no-cache add \
     ca-certificates \
     iptables

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.1 AS BUILDER
+FROM golang:1.19.5 AS BUILDER
 WORKDIR /go/src/github.com/jtblin/kube2iam
 ENV ARCH=linux
 ENV CGO_ENABLED=0


### PR DESCRIPTION
#### What this PR does / why we need it:

Resolving underlying alpine vulnerabilities. Built locally to confirm it still builds

Trivy output (generated via `trivy image jtblin/kube2iam:0.11.1 --security-checks vuln --output kube2iam-0.11.1`):

```
jtblin/kube2iam:0.11.1 (alpine 3.14.3)
======================================
Total: 9 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 6, CRITICAL: 1)

┌──────────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│   Library    │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ busybox      │ CVE-2022-28391 │ HIGH     │ 1.33.1-r6         │ 1.33.1-r7     │ busybox: remote attackers may execute arbitrary code if     │
│              │                │          │                   │               │ netstat is used                                             │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-28391                  │
├──────────────┼────────────────┤          ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto1.1 │ CVE-2022-0778  │          │ 1.1.1l-r0         │ 1.1.1n-r0     │ openssl: Infinite loop in BN_mod_sqrt() reachable when      │
│              │                │          │                   │               │ parsing certificates                                        │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-0778                   │
│              ├────────────────┼──────────┤                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-2097  │ MEDIUM   │                   │ 1.1.1q-r0     │ openssl: AES OCB fails to encrypt some bytes                │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-2097                   │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libretls     │ CVE-2022-0778  │ HIGH     │ 3.3.3p1-r2        │ 3.3.3p1-r3    │ openssl: Infinite loop in BN_mod_sqrt() reachable when      │
│              │                │          │                   │               │ parsing certificates                                        │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-0778                   │
├──────────────┤                │          ├───────────────────┼───────────────┤                                                             │
│ libssl1.1    │                │          │ 1.1.1l-r0         │ 1.1.1n-r0     │                                                             │
│              │                │          │                   │               │                                                             │
│              │                │          │                   │               │                                                             │
│              ├────────────────┼──────────┤                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-2097  │ MEDIUM   │                   │ 1.1.1q-r0     │ openssl: AES OCB fails to encrypt some bytes                │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-2097                   │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ ssl_client   │ CVE-2022-28391 │ HIGH     │ 1.33.1-r6         │ 1.33.1-r7     │ busybox: remote attackers may execute arbitrary code if     │
│              │                │          │                   │               │ netstat is used                                             │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-28391                  │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ zlib         │ CVE-2022-37434 │ CRITICAL │ 1.2.11-r3         │ 1.2.12-r2     │ zlib: heap-based buffer over-read and overflow in inflate() │
│              │                │          │                   │               │ in inflate.c via a...                                       │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-37434                  │
│              ├────────────────┼──────────┤                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2018-25032 │ HIGH     │                   │ 1.2.12-r0     │ zlib: A flaw found in zlib when compressing (not            │
│              │                │          │                   │               │ decompressing) certain inputs...                            │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2018-25032                  │
└──────────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘

bin/kube2iam (gobinary)
=======================
Total: 20 (UNKNOWN: 0, LOW: 1, MEDIUM: 8, HIGH: 11, CRITICAL: 0)

┌─────────────────────────────────────┬─────────────────────┬──────────┬──────────────────────────────────────┬───────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│               Library               │    Vulnerability    │ Severity │          Installed Version           │           Fixed Version           │                            Title                             │
├─────────────────────────────────────┼─────────────────────┼──────────┼──────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go           │ CVE-2020-8911       │ MEDIUM   │ v1.8.7                               │                                   │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto    │
│                                     │                     │          │                                      │                                   │ SDK for golang...                                            │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2020-8911                    │
│                                     ├─────────────────────┤          │                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-2582       │          │                                      │ 1.34.0                            │ The AWS S3 Crypto SDK sends an unencrypted hash of the       │
│                                     │                     │          │                                      │                                   │ plaintext...                                                 │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2022-2582                    │
│                                     ├─────────────────────┤          │                                      │                                   ├──────────────────────────────────────────────────────────────┤
│                                     │ GHSA-76wf-9vgp-pj7w │          │                                      │                                   │ Unencrypted md5 plaintext hash in metadata in AWS S3 Crypto  │
│                                     │                     │          │                                      │                                   │ SDK for...                                                   │
│                                     │                     │          │                                      │                                   │ https://github.com/advisories/GHSA-76wf-9vgp-pj7w            │
│                                     ├─────────────────────┼──────────┤                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2020-8912       │ LOW      │                                      │                                   │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto   │
│                                     │                     │          │                                      │                                   │ SDK for golang...                                            │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2020-8912                    │
├─────────────────────────────────────┼─────────────────────┼──────────┼──────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/gogo/protobuf            │ CVE-2021-3121       │ HIGH     │ v1.2.2-0.20190723190241-65acae22fc9d │ 1.3.2                             │ gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain   │
│                                     │                     │          │                                      │                                   │ index validation                                             │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2021-3121                    │
├─────────────────────────────────────┼─────────────────────┤          ├──────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/prometheus/client_golang │ CVE-2022-21698      │          │ v0.9.0-pre1                          │ 1.11.1                            │ prometheus/client_golang: Denial of service using            │
│                                     │                     │          │                                      │                                   │ InstrumentHandlerCounter                                     │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2022-21698                   │
├─────────────────────────────────────┼─────────────────────┤          ├──────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto                 │ CVE-2020-29652      │          │ v0.0.0-20191011191535-87dc89f01550   │ 0.0.0-20201216223049-8b5274cf687f │ golang: crypto/ssh: crafted authentication request can lead  │
│                                     │                     │          │                                      │                                   │ to nil pointer dereference                                   │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2020-29652                   │
│                                     ├─────────────────────┤          │                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2020-7919       │          │                                      │ 0.0.0-20200124225646-8b5121be2f68 │ golang: Integer overflow on 32bit architectures via crafted  │
│                                     │                     │          │                                      │                                   │ certificate allows for denial...                             │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2020-7919                    │
│                                     ├─────────────────────┤          │                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2021-43565      │          │                                      │ 0.0.0-20211202192323-5770296d904e │ golang.org/x/crypto: empty plaintext packet causes panic     │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2021-43565                   │
│                                     ├─────────────────────┤          │                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-27191      │          │                                      │ 0.0.0-20220314234659-1baeb1ce4c0b │ golang: crash in a golang.org/x/crypto/ssh server            │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2022-27191                   │
│                                     ├─────────────────────┼──────────┤                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2020-9283       │ MEDIUM   │                                      │ 0.0.0-20200220183623-bac4c82f6975 │ golang.org/x/crypto: Processing of crafted ssh-ed25519       │
│                                     │                     │          │                                      │                                   │ public keys allows for panic                                 │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2020-9283                    │
├─────────────────────────────────────┼─────────────────────┼──────────┼──────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net                    │ CVE-2021-33194      │ HIGH     │ v0.0.0-20210405180319-a5a99cb37ef4   │ 0.0.0-20210520170846-37e1c6afe023 │ golang: x/net/html: infinite loop in ParseFragment           │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2021-33194                   │
│                                     ├─────────────────────┤          │                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2021-44716      │          │                                      │ 0.0.0-20211209124913-491a49abca63 │ golang: net/http: limit growth of header canonicalization    │
│                                     │                     │          │                                      │                                   │ cache                                                        │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2021-44716                   │
│                                     ├─────────────────────┤          │                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-27664      │          │                                      │ 0.0.0-20220906165146-f3363e06e74c │ golang: net/http: handle server errors after sending GOAWAY  │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2022-27664                   │
│                                     ├─────────────────────┼──────────┤                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2021-31525      │ MEDIUM   │                                      │ 0.0.0-20210428140749-89ef3d95e781 │ golang: net/http: panic in ReadRequest and ReadResponse when │
│                                     │                     │          │                                      │                                   │ reading a very large...                                      │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2021-31525                   │
│                                     ├─────────────────────┤          │                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-41717      │          │                                      │ 0.4.0                             │ golang: net/http: An attacker can cause excessive memory     │
│                                     │                     │          │                                      │                                   │ growth in a Go...                                            │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2022-41717                   │
├─────────────────────────────────────┼─────────────────────┤          ├──────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/sys                    │ CVE-2022-29526      │          │ v0.0.0-20210510120138-977fb7262007   │ 0.0.0-20220412211240-33da011f77ad │ golang: syscall: faccessat checks wrong group                │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2022-29526                   │
├─────────────────────────────────────┼─────────────────────┼──────────┼──────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/text                   │ CVE-2021-38561      │ HIGH     │ v0.3.3                               │ 0.3.7                             │ golang: out-of-bounds read in golang.org/x/text/language     │
│                                     │                     │          │                                      │                                   │ leads to DoS                                                 │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2021-38561                   │
│                                     ├─────────────────────┤          │                                      ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-32149      │          │                                      │ 0.3.8                             │ golang: golang.org/x/text/language: ParseAcceptLanguage      │
│                                     │                     │          │                                      │                                   │ takes a long time to parse complex tags                      │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2022-32149                   │
├─────────────────────────────────────┼─────────────────────┼──────────┼──────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ k8s.io/client-go                    │ CVE-2020-8565       │ MEDIUM   │ v0.17.3                              │ 0.20.0-alpha.2                    │ kubernetes: Incomplete fix for CVE-2019-11250 allows for     │
│                                     │                     │          │                                      │                                   │ token leak in logs when...                                   │
│                                     │                     │          │                                      │                                   │ https://avd.aquasec.com/nvd/cve-2020-8565                    │
└─────────────────────────────────────┴─────────────────────┴──────────┴──────────────────────────────────────┴───────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes:

#### Checklist chart
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
