### PR TITLE
Update Alpine to 3.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV CGO_ENABLED=0
 COPY . ./
 RUN make setup && make build
 
-FROM alpine:3.18.4
+FROM alpine:3.20.2
 RUN apk --no-cache add \
     ca-certificates \
     iptables


### PR DESCRIPTION
#### What this PR does / why we need it:

Update Alpine to 3.20.2 to fix a number of CVEs in SSL libraries.
Would you be so kind to tag 0.11.3 with this? :heart: 
 
#### Special notes:

#### Checklist chart
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
