### PR TITLE
fix: Upgrade Golang builder version to `1.22.7`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.4 AS BUILDER
+FROM golang:1.22.7 AS BUILDER
 WORKDIR /go/src/github.com/jtblin/kube2iam
 ENV ARCH=linux
 ENV CGO_ENABLED=0


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes Docker image builder.

#### Which issue this PR fixes
- Docker builder [fails](https://app.circleci.com/pipelines/circleci/Tv5Xa331HXLx98iuW72Ug4/Po3PqWxjiikmpntHfiZoXW/31/workflows/9fc52610-1f97-4bfd-8687-3a32acc79d2e/jobs/49) due to Golang version, this PR upgrades the Golang version to build the image successfully.

#### Special notes:

#### Checklist chart
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
