### PR TITLE
Make parseRemoteAddr handle IPv6 addresses

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -95,7 +95,7 @@ func (k8s *Client) PodByIP(IP string) (*v1.Pod, error) {
 
 	if len(pods) == 0 {
 		metrics.PodNotFoundInCache.Inc()
-		return nil, fmt.Errorf("pod with specificed IP not found")
+		return nil, fmt.Errorf("pod with specificed IP %q not found", IP)
 	}
 
 	if len(pods) == 1 {

--- a/server/server.go
+++ b/server/server.go
@@ -159,15 +159,18 @@ func newAppHandler(name string, fn appHandlerFunc) *appHandler {
 }
 
 func parseRemoteAddr(addr string) string {
-	n := strings.IndexByte(addr, ':')
-	if n <= 1 {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// If no port, try parsing as pure IP
+		host = addr
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
 		return ""
 	}
-	hostname := addr[0:n]
-	if net.ParseIP(hostname) == nil {
-		return ""
-	}
-	return hostname
+
+	return ip.String()
 }
 
 func (s *Server) getRoleMapping(IP string) (*mappings.RoleMappingResult, error) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,44 @@
+package server
+
+import "testing"
+
+func TestParseRemoteAddr(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		addr     string
+		expected string
+	}{
+		{
+			name:     "parse IPv4 address without port",
+			addr:     "192.168.0.1",
+			expected: "192.168.0.1",
+		},
+		{
+			name:     "parse IPv4 address with port",
+			addr:     "192.168.0.1:8181",
+			expected: "192.168.0.1",
+		},
+		{
+			name:     "parse IPv6 address without port",
+			addr:     "fd00:ec2::254",
+			expected: "fd00:ec2::254",
+		},
+		{
+			name:     "parse IPv6 address with port",
+			addr:     "[fd00:ec2::254]:8181",
+			expected: "fd00:ec2::254",
+		},
+		{
+			name:     "parse invalid address",
+			addr:     "abcd",
+			expected: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseRemoteAddr(tc.addr)
+			if got != tc.expected {
+				t.Errorf("parseRemoteAddr(%q) = %q; want %q", tc.addr, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

This fixes the function `parseRemoteAddr` to be compatible with both IPv4 and IPv6 addresses. This enables kube2iam to work in an IPv6 enabled cluster where the pod IPs and thereby source IP/RemoteAddr would be IPv6. Without the fix, the RemoteAddr is parsed as `""` and is not mapped to the pod making the call.

Additionally it adds the address to an error so it's easier to debug issues.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes:

#### Checklist chart
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
