### PR TITLE
Trigger workflow on branches and tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,5 @@ workflows:
             - build-and-test
             - docker-buildx
           filters:
-            branches:
-              only:
-                - master
-                - /release-[\w\.]+/
+            tags:
+              only: /.*/


### PR DESCRIPTION
Remove restriction to only build master and release-* branches and execute workflow for tags.