### PR TITLE
Support kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ Usage of kube2iam:
       --iam-external-id string                Pod annotation key used to retrieve the IAM ExternalId (default "iam.amazonaws.com/external-id")
       --insecure                              Kubernetes server should be accessed without verifying the TLS. Testing only
       --iptables                              Add iptables rule (also requires --host-ip)
+      --kubeconfig string                     Path to kubeconfig
       --log-format string                     Log format (text/json) (default "text")
       --log-level string                      Log level (default "info")
       --metadata-addr string                  Address for the ec2 metadata (default "169.254.169.254")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 
 // addFlags adds the command line flags.
 func addFlags(s *server.Server, fs *pflag.FlagSet) {
+	fs.StringVar(&s.KubeconfigPath, "kubeconfig", "", "Path to kubeconfig")
 	fs.StringVar(&s.APIServer, "api-server", s.APIServer, "Endpoint for the api server")
 	fs.StringVar(&s.APIToken, "api-token", s.APIToken, "Token to authenticate with the api server")
 	fs.StringVar(&s.AppPort, "app-port", s.AppPort, "Kube2iam server http port")
@@ -114,7 +115,7 @@ func main() {
 		}
 	}
 
-	if err := s.Run(s.APIServer, s.APIToken, s.NodeName, s.Insecure); err != nil {
+	if err := s.Run(s.KubeconfigPath, s.APIServer, s.APIToken, s.NodeName, s.Insecure); err != nil {
 		log.Fatalf("%s", err)
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,7 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -153,10 +154,15 @@ func (k8s *Client) NamespaceByName(namespaceName string) (*v1.Namespace, error) 
 }
 
 // NewClient returns a new kubernetes client.
-func NewClient(host, token, nodeName string, insecure, resolveDupIPs bool) (*Client, error) {
+func NewClient(kubeconfigPath, host, token, nodeName string, insecure, resolveDupIPs bool) (*Client, error) {
 	var config *rest.Config
 	var err error
-	if host != "" && token != "" {
+	if kubeconfigPath != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return nil, err
+		}
+	} else if host != "" && token != "" {
 		config = &rest.Config{
 			Host:        host,
 			BearerToken: token,

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -158,10 +159,19 @@ func (k8s *Client) NamespaceByName(namespaceName string) (*v1.Namespace, error) 
 }
 
 // NewClient returns a new kubernetes client.
-func NewClient(host, token, nodeName string, insecure, resolveDupIPs bool) (*Client, error) {
+func NewClient(kubeconfigPath, host, token, nodeName string, insecure, resolveDupIPs bool) (*Client, error) {
 	var config *rest.Config
 	var err error
-	if host != "" && token != "" {
+	if kubeconfigPath != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return nil, err
+		}
+		// Honor the CLI flag as an override
+		if insecure {
+			config.Insecure = true
+		}
+	} else if host != "" && token != "" {
 		config = &rest.Config{
 			Host:        host,
 			BearerToken: token,

--- a/server/server.go
+++ b/server/server.go
@@ -50,6 +50,7 @@ var registeredHandlerNames []string
 // Server encapsulates all of the parameters necessary for starting up
 // the server. These can either be set via command line or directly.
 type Server struct {
+	KubeconfigPath             string
 	APIServer                  string
 	APIToken                   string
 	AppPort                    string
@@ -368,8 +369,8 @@ func write(logger *log.Entry, w http.ResponseWriter, s string) {
 }
 
 // Run runs the specified Server.
-func (s *Server) Run(host, token, nodeName string, insecure bool) error {
-	k, err := k8s.NewClient(host, token, nodeName, insecure, s.ResolveDupIPs)
+func (s *Server) Run(kubeconfigPath, host, token, nodeName string, insecure bool) error {
+	k, err := k8s.NewClient(kubeconfigPath, host, token, nodeName, insecure, s.ResolveDupIPs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

Enables users to connect kube2iam to kube-apiserver using a kubeconfig file by passing in the file path to `--kubeconfig`.
