### PR TITLE
Update Golang + Alpine versions past vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.24.3 AS BUILDER
+FROM golang:1.24.11 AS BUILDER
 WORKDIR /go/src/github.com/jtblin/kube2iam
 ENV ARCH=linux
 ENV CGO_ENABLED=0
 COPY . ./
 RUN make setup && make build
 
-FROM alpine:3.20.6
+FROM alpine:3.20.8
 RUN apk --no-cache add \
     ca-certificates \
     iptables


### PR DESCRIPTION
#### What this PR does / why we need it:

Based on the [Alpine](https://alpinelinux.org/posts/Alpine-3.19.9-3.20.8-3.21.5-3.22.2-released.html) release notes:

> These updates include security fixes for OpenSSL addressing the September 30, 2025 advisory (CVE-2025-9230, CVE-2025-9231, CVE-2025-9232).

And the [Golang](https://groups.google.com/g/golang-announce/c/8FJoBkPddm4/m/kYpVlPw1CQAJ) release notes:

> These releases include 2 security fixes following the security policy:
>    crypto/x509: excessive resource consumption in printing error string for host certificate validation
>    [...]
>    This is CVE-2025-61729 and Go issue https://go.dev/issue/76445.
>
>    crypto/x509: excluded subdomain constraint does not restrict wildcard SANs
>    [...]
>    This is CVE-2025-61727 and Go issue https://go.dev/issue/76442.

#### Special notes:

#### Checklist chart
- [ ] Chart Version bumped

I'm not sure a chart version bump is required until a new release is cut?
