### PR TITLE
Add AssumeRole error cache (Modernized #200)

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,13 +710,14 @@ Usage of kube2iam:
       --backoff-max-elapsed-time duration     Max elapsed time for backoff when querying for role. (default 2s)
       --backoff-max-interval duration         Max interval for backoff when querying for role. (default 1s)
       --base-role-arn string                  Base role ARN
-      --iam-role-session-ttl                  Length of session when assuming the roles (default 15m)
       --debug                                 Enable debug features
       --default-role string                   Fallback role to use when annotation is not set
       --host-interface string                 Host interface for proxying AWS metadata (default "docker0")
       --host-ip string                        IP address of host
+      --iam-role-error-ttl duration           TTL for caching assume role errors
       --iam-role-key string                   Pod annotation key used to retrieve the IAM role (default "iam.amazonaws.com/role")
       --iam-external-id string                Pod annotation key used to retrieve the IAM ExternalId (default "iam.amazonaws.com/external-id")
+      --iam-role-session-ttl duration         TTL for the assume role session (default 15m0s)
       --insecure                              Kubernetes server should be accessed without verifying the TLS. Testing only
       --iptables                              Add iptables rule (also requires --host-ip)
       --kubeconfig string                     Path to kubeconfig
@@ -733,6 +734,7 @@ Usage of kube2iam:
       --use-regional-sts-endpoint             use the regional sts endpoint if AWS_REGION is set
       --verbose                               Verbose
       --version                               Print the version and exits
+
 ```
 
 ## Development loop

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.StringVar(&s.IAMRoleKey, "iam-role-key", s.IAMRoleKey, "Pod annotation key used to retrieve the IAM role")
 	fs.StringVar(&s.IAMExternalID, "iam-external-id", s.IAMExternalID, "Pod annotation key used to retrieve the IAM ExternalId")
 	fs.DurationVar(&s.IAMRoleSessionTTL, "iam-role-session-ttl", s.IAMRoleSessionTTL, "TTL for the assume role session")
+	fs.DurationVar(&s.IAMRoleErrorTTL, "iam-role-error-ttl", s.IAMRoleErrorTTL, "TTL for caching assume role errors")
 	fs.BoolVar(&s.Insecure, "insecure", false, "Kubernetes server should be accessed without verifying the TLS. Testing only")
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the ec2 metadata")
 	fs.BoolVar(&s.AddIPTablesRule, "iptables", false, "Add iptables rule (also requires --host-ip)")

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -21,6 +21,8 @@ import (
 
 var cache = ccache.New(ccache.Configure())
 
+var errorCache = ccache.New(ccache.Configure())
+
 const (
 	maxSessNameLength = 64
 )
@@ -50,6 +52,7 @@ type Client struct {
 	Region              RegionClient
 	IMDS                IMDSClient
 	Cache               *ccache.Cache
+	ErrorCache          *ccache.Cache
 }
 
 // Credentials represent the security Credentials response.
@@ -177,6 +180,13 @@ func (iam *Client) getCache() *ccache.Cache {
 	return cache
 }
 
+func (iam *Client) getErrorCache() *ccache.Cache {
+	if iam.ErrorCache != nil {
+		return iam.ErrorCache
+	}
+	return errorCache
+}
+
 // Regions list to validate input region name
 //
 // https://stackoverflow.com/a/69935735/3945261
@@ -206,9 +216,13 @@ func (iam *Client) getRegions() (*ec2.DescribeRegionsOutput, error) {
 }
 
 // AssumeRole returns an IAM role Credentials using AWS STS.
-func (iam *Client) AssumeRole(roleARN, externalID string, remoteIP string, sessionTTL time.Duration) (*Credentials, error) {
+func (iam *Client) AssumeRole(roleARN, externalID string, remoteIP string, sessionTTL time.Duration, errorTTL time.Duration) (*Credentials, error) {
 	hitCache := true
 	item, err := iam.getCache().Fetch(roleARN, sessionTTL, func() (interface{}, error) {
+		errItem := iam.getErrorCache().Get(roleARN)
+		if errItem != nil && !errItem.Expired() {
+			return nil, errItem.Value().(error)
+		}
 		hitCache = false
 
 		// Set up a prometheus timer to track the AWS request duration. It stores the timer value when
@@ -222,6 +236,7 @@ func (iam *Client) AssumeRole(roleARN, externalID string, remoteIP string, sessi
 
 		regions, err := iam.getRegions()
 		if err != nil {
+			iam.getErrorCache().Set(roleARN, err, errorTTL)
 			return nil, err
 		}
 
@@ -244,6 +259,7 @@ func (iam *Client) AssumeRole(roleARN, externalID string, remoteIP string, sessi
 				config.WithEndpointResolverWithOptions(customSTSResolver), //nolint:staticcheck
 			)
 			if err != nil {
+				iam.getErrorCache().Set(roleARN, err, errorTTL)
 				return nil, err
 			}
 			svc = sts.NewFromConfig(cfg)
@@ -264,6 +280,7 @@ func (iam *Client) AssumeRole(roleARN, externalID string, remoteIP string, sessi
 		// https://github.com/aws/aws-sdk-go-v2/blob/credentials/v1.12.10/credentials/stscreds/assume_role_provider.go#L270
 		resp, err := svc.AssumeRole(context.TODO(), &assumeRoleInput)
 		if err != nil {
+			iam.getErrorCache().Set(roleARN, err, errorTTL)
 			return nil, err
 		}
 

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -221,7 +221,8 @@ func TestGetIAMCode(t *testing.T) {
 
 func newTestIAMClient() *Client {
 	return &Client{
-		Cache: ccache.New(ccache.Configure()),
+		Cache:      ccache.New(ccache.Configure()),
+		ErrorCache: ccache.New(ccache.Configure()),
 		Region: &MockRegionClient{
 			DescribeRegionsFunc: func(ctx context.Context, params *ec2.DescribeRegionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRegionsOutput, error) {
 				return &validEc2Regions, nil
@@ -245,7 +246,7 @@ func TestAssumeRole(t *testing.T) {
 		},
 	}
 
-	creds, err := iamClient.AssumeRole("arn:aws:iam::123456789012:role/role", "", "1.2.3.4", time.Minute)
+	creds, err := iamClient.AssumeRole("arn:aws:iam::123456789012:role/role", "", "1.2.3.4", time.Minute, time.Minute)
 	if err != nil {
 		t.Fatalf("AssumeRole failed: %v", err)
 	}
@@ -274,7 +275,7 @@ func TestAssumeRoleWithExternalID(t *testing.T) {
 		},
 	}
 
-	_, err := iamClient.AssumeRole("arn:aws:iam::123456789012:role/role", "my-external-id", "1.2.3.4", time.Minute)
+	_, err := iamClient.AssumeRole("arn:aws:iam::123456789012:role/role", "my-external-id", "1.2.3.4", time.Minute, time.Minute)
 	if err != nil {
 		t.Fatalf("AssumeRole failed: %v", err)
 	}
@@ -300,7 +301,7 @@ func TestAssumeRoleWithoutExternalIDNotSet(t *testing.T) {
 		},
 	}
 
-	_, err := iamClient.AssumeRole("arn:aws:iam::123456789012:role/role", "", "1.2.3.4", time.Minute)
+	_, err := iamClient.AssumeRole("arn:aws:iam::123456789012:role/role", "", "1.2.3.4", time.Minute, time.Minute)
 	if err != nil {
 		t.Fatalf("AssumeRole failed: %v", err)
 	}
@@ -317,7 +318,7 @@ func TestAssumeRoleError(t *testing.T) {
 		},
 	}
 
-	_, err := iamClient.AssumeRole("arn:aws:iam::123456789012:role/role", "", "1.2.3.4", time.Minute)
+	_, err := iamClient.AssumeRole("arn:aws:iam::123456789012:role/role", "", "1.2.3.4", time.Minute, time.Minute)
 	if err == nil {
 		t.Fatal("expected error from AssumeRole but got nil")
 	}
@@ -342,7 +343,7 @@ func TestAssumeRoleCache(t *testing.T) {
 
 	roleARN := "arn:aws:iam::123456789012:role/cached-role"
 	for i := 0; i < 3; i++ {
-		_, err := iamClient.AssumeRole(roleARN, "", "1.2.3.4", time.Hour)
+		_, err := iamClient.AssumeRole(roleARN, "", "1.2.3.4", time.Hour, time.Minute)
 		if err != nil {
 			t.Fatalf("AssumeRole call %d failed: %v", i, err)
 		}
@@ -355,7 +356,8 @@ func TestAssumeRoleCache(t *testing.T) {
 
 func TestAssumeRoleRegionError(t *testing.T) {
 	iamClient := &Client{
-		Cache: ccache.New(ccache.Configure()),
+		Cache:      ccache.New(ccache.Configure()),
+		ErrorCache: ccache.New(ccache.Configure()),
 		Region: &MockRegionClient{
 			DescribeRegionsFunc: func(ctx context.Context, params *ec2.DescribeRegionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRegionsOutput, error) {
 				return nil, errors.New("describe regions failed")
@@ -368,9 +370,76 @@ func TestAssumeRoleRegionError(t *testing.T) {
 		},
 	}
 
-	_, err := iamClient.AssumeRole("arn:aws:iam::123456789012:role/role", "", "1.2.3.4", time.Minute)
+	_, err := iamClient.AssumeRole("arn:aws:iam::123456789012:role/role", "", "1.2.3.4", time.Minute, time.Minute)
 	if err == nil {
 		t.Fatal("expected error when DescribeRegions fails")
+	}
+}
+
+func TestAssumeRoleErrorCaching(t *testing.T) {
+	callCount := 0
+	iamClient := newTestIAMClient()
+	iamClient.STS = &MockSTSClient{
+		AssumeRoleFunc: func(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+			callCount++
+			return nil, errors.New("sts error")
+		},
+	}
+
+	roleARN := "arn:aws:iam::123456789012:role/role"
+	_, err := iamClient.AssumeRole(roleARN, "", "1.2.3.4", time.Minute, time.Minute)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 call to STS, got %d", callCount)
+	}
+
+	// Second call should be cached
+	_, err = iamClient.AssumeRole(roleARN, "", "1.2.3.4", time.Minute, time.Minute)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected still 1 call to STS (cached), got %d", callCount)
+	}
+}
+
+func TestAssumeRoleErrorCachingTTL(t *testing.T) {
+	callCount := 0
+	iamClient := newTestIAMClient()
+	iamClient.STS = &MockSTSClient{
+		AssumeRoleFunc: func(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+			callCount++
+			return nil, errors.New("sts error")
+		},
+	}
+
+	roleARN := "arn:aws:iam::123456789012:role/role"
+	errorTTL := 100 * time.Millisecond
+
+	_, err := iamClient.AssumeRole(roleARN, "", "1.2.3.4", time.Minute, errorTTL)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 call to STS, got %d", callCount)
+	}
+
+	// Wait for TTL to expire
+	time.Sleep(errorTTL + 10*time.Millisecond)
+
+	// Third call should NOT be cached
+	_, err = iamClient.AssumeRole(roleARN, "", "1.2.3.4", time.Minute, errorTTL)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 calls to STS (expired cache), got %d", callCount)
 	}
 }
 

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -81,7 +81,7 @@ func (k8s *Client) WatchForNamespaces(nsEventLogger cache.ResourceEventHandler, 
 func (k8s *Client) ListPodIPs() []string {
 	// Decided to simply dump this and leave it up to consumer
 	// as k8s package currently doesn't need to be concerned about what's
-	// a signficant annotation to process, that is left up to store/server
+	// a significant annotation to process, that is left up to store/server
 	return k8s.podIndexer.ListIndexFuncValues(podIPIndexName)
 }
 

--- a/mappings/mapper_test.go
+++ b/mappings/mapper_test.go
@@ -77,11 +77,11 @@ func TestExtractRoleARN(t *testing.T) {
 
 			resp, err := rp.extractRoleARN(pod)
 			if tt.expectError && err == nil {
-				t.Error("Expected error however didn't recieve one")
+				t.Error("Expected error however didn't receive one")
 				return
 			}
 			if !tt.expectError && err != nil {
-				t.Errorf("Didn't expect error but recieved %s", err)
+				t.Errorf("Didn't expect error but received %s", err)
 				return
 			}
 			if resp != tt.expectedARN {
@@ -374,7 +374,7 @@ func TestCheckRoleForNamespace(t *testing.T) {
 
 			resp := rp.checkRoleForNamespace(tt.roleARN, tt.namespace)
 			if resp != tt.expectedResult {
-				t.Errorf("Expected [%t] for test but recieved [%t]", tt.expectedResult, resp)
+				t.Errorf("Expected [%t] for test but received [%t]", tt.expectedResult, resp)
 			}
 		})
 	}

--- a/server/integration_test.go
+++ b/server/integration_test.go
@@ -309,7 +309,8 @@ func TestIntegRoleCredentialCaching(t *testing.T) {
 
 	iamClient := &iam.Client{
 		BaseARN: baseARN,
-		Cache:   ccache.New(ccache.Configure()),
+		Cache:      ccache.New(ccache.Configure()),
+		ErrorCache: ccache.New(ccache.Configure()),
 		STS:     stsClient,
 		Region: &mockRegionClient2{regions: []types.Region{
 			{RegionName: aws.String("us-east-1"), Endpoint: aws.String("ec2.us-east-1.amazonaws.com")},
@@ -320,7 +321,7 @@ func TestIntegRoleCredentialCaching(t *testing.T) {
 
 	// Make 5 AssumeRole calls for the same ARN
 	for i := 0; i < 5; i++ {
-		_, err := iamClient.AssumeRole(roleARN, "", "10.10.0.4", time.Hour)
+		_, err := iamClient.AssumeRole(roleARN, "", "10.10.0.4", time.Hour, time.Minute)
 		if err != nil {
 			t.Fatalf("call %d: AssumeRole failed: %v", i+1, err)
 		}
@@ -341,14 +342,8 @@ func (c *countingSTSClient) AssumeRole(ctx context.Context, params *sts.AssumeRo
 	return c.delegate.AssumeRole(ctx, params, optFns...)
 }
 
-// TestIntegErrorCachingCurrentBehavior documents that the current implementation
-// does NOT cache STS errors — each failing request hits STS again.
-// This is a known gap: error caching would protect against AWS rate limits during
-// transient STS failures. When error caching is implemented, update this test.
-//
-// TODO: Implement error caching with 1-minute TTL and update this test to assert
-// callCount == 1 after the first error is returned.
-func TestIntegErrorCachingCurrentBehavior(t *testing.T) {
+// TestIntegErrorCaching ensures that STS errors are cached.
+func TestIntegErrorCaching(t *testing.T) {
 	const (
 		baseARN  = "arn:aws:iam::123456789012:role/"
 		roleName = "failing-role"
@@ -361,9 +356,10 @@ func TestIntegErrorCachingCurrentBehavior(t *testing.T) {
 	}
 
 	iamClient := &iam.Client{
-		BaseARN: baseARN,
-		Cache:   ccache.New(ccache.Configure()),
-		STS:     stsClient,
+		BaseARN:    baseARN,
+		Cache:      ccache.New(ccache.Configure()),
+		ErrorCache: ccache.New(ccache.Configure()),
+		STS:        stsClient,
 		Region: &mockRegionClient2{regions: []types.Region{
 			{RegionName: aws.String("us-east-1"), Endpoint: aws.String("ec2.us-east-1.amazonaws.com")},
 		}},
@@ -373,18 +369,16 @@ func TestIntegErrorCachingCurrentBehavior(t *testing.T) {
 	const numCalls = 5
 
 	for i := 0; i < numCalls; i++ {
-		_, err := iamClient.AssumeRole(roleARN, "", "10.10.0.5", time.Hour)
+		_, err := iamClient.AssumeRole(roleARN, "", "10.10.0.5", time.Hour, time.Minute)
 		if err == nil {
 			t.Errorf("call %d: expected error, got nil", i+1)
 		}
 	}
 
-	// Document current behavior: errors are not cached, STS is hit on each call.
-	if callCount != numCalls {
-		t.Errorf("current behavior: expected %d STS calls (no error caching), got %d", numCalls, callCount)
+	// Now that error caching is implemented, STS should only be called once.
+	if callCount != 1 {
+		t.Errorf("expected 1 STS call (with error caching), got %d", callCount)
 	}
-	t.Logf("NOTE: Error caching not yet implemented. STS was called %d times for %d requests. "+
-		"Implementing a 1-minute error cache would reduce this to 1.", callCount, numCalls)
 }
 
 // TestIntegHealthcheck verifies the doHealthcheck sets instanceID from IMDS

--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,7 @@ const (
 	defaultLogFormat                  = "text"
 	defaultMaxElapsedTime             = 2 * time.Second
 	defaultIAMRoleSessionTTL          = 15 * time.Minute
+	defaultIAMRoleErrorTTL            = 0
 	defaultMaxInterval                = 1 * time.Second
 	defaultMetadataAddress            = "169.254.169.254"
 	defaultNamespaceKey               = "iam.amazonaws.com/allowed-roles"
@@ -60,6 +61,7 @@ type Server struct {
 	IAMRoleKey                 string
 	IAMExternalID              string
 	IAMRoleSessionTTL          time.Duration
+	IAMRoleErrorTTL            time.Duration
 	MetadataAddress            string
 	HostInterface              string
 	HostIP                     string
@@ -335,7 +337,7 @@ func (s *Server) roleHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	credentials, err := s.iam.AssumeRole(wantedRoleARN, externalID, remoteIP, s.IAMRoleSessionTTL)
+	credentials, err := s.iam.AssumeRole(wantedRoleARN, externalID, remoteIP, s.IAMRoleSessionTTL, s.IAMRoleErrorTTL)
 	if err != nil {
 		roleLogger.Errorf("Error assuming role %+v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -444,5 +446,6 @@ func NewServer() *Server {
 		NamespaceRestrictionFormat: defaultNamespaceRestrictionFormat,
 		HealthcheckFailReason:      "Healthcheck not yet performed",
 		IAMRoleSessionTTL:          defaultIAMRoleSessionTTL,
+		IAMRoleErrorTTL:            defaultIAMRoleErrorTTL,
 	}
 }


### PR DESCRIPTION
Originally proposed by @schleyfox in #200.

This PR adds a negative cache on AssumeRole to prevent error cases from spamming the AWS API. This is set to 0 by default to preserve existing behavior, but a value of 30 seconds to 1 minute would be reasonable.

Modernization changes:
- Rebased onto `main`.
- Resolved conflicts in `iam.go`, `server.go`, and `mappings/mapper.go`.
- Integrated with existing `externalID` support.
- Updated documentation and CLI flags.
- Preserved original contributor attribution.